### PR TITLE
Allow HTTP basic authentication in addition to bearer

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -336,16 +337,28 @@ func validateAuth(auth string) bool {
 
 	parts := strings.Split(auth, " ")
 
-	// Expect ["Bearer", "sk_test_123"]
-	if len(parts) != 2 {
+	// Expect ["Bearer", "sk_test_123"] or ["Basic", "aaaaa"]
+	if len(parts) != 2 || parts[1] == "" {
 		return false
 	}
 
-	if parts[0] != "Bearer" {
+	var key string
+	switch parts[0] {
+	case "Basic":
+		keyBytes, err := base64.StdEncoding.DecodeString(parts[1])
+		if err != nil {
+			return false
+		}
+		key = string(keyBytes)
+
+	case "Bearer":
+		key = parts[1]
+
+	default:
 		return false
 	}
 
-	keyParts := strings.Split(parts[1], "_")
+	keyParts := strings.Split(key, "_")
 
 	// Expect ["sk", "test", "123"]
 	if len(keyParts) != 3 {

--- a/server_test.go
+++ b/server_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -152,9 +153,15 @@ func TestValidateAuth(t *testing.T) {
 		auth string
 		want bool
 	}{
+		{"Basic " + encode64("sk_test_123"), true},
 		{"Bearer sk_test_123", true},
 		{"", false},
 		{"Bearer", false},
+		{"Basic", false},
+		{"Bearer ", false},
+		{"Basic ", false},
+		{"Basic 123", false}, // "123" is not a valid key when decoded
+		{"Basic " + encode64("sk_test"), false},
 		{"Bearer sk_test_123 extra", false},
 		{"Bearer sk_test", false},
 		{"Bearer sk_test_123_extra", false},
@@ -171,6 +178,10 @@ func TestValidateAuth(t *testing.T) {
 //
 // ---
 //
+
+func encode64(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
 
 func getStubServer(t *testing.T) *StubServer {
 	server := &StubServer{spec: testSpec}


### PR DESCRIPTION
The real Stripe API allows basic authentication so lets allow it from stripe-mock as well.