### PR TITLE
Fix concurrent generator use

### DIFF
--- a/generator_test.go
+++ b/generator_test.go
@@ -57,7 +57,7 @@ func TestGenerateResponseData(t *testing.T) {
 	var generator DataGenerator
 
 	// basic reference
-	generator = DataGenerator{testSpec.Definitions, testFixtures}
+	generator = DataGenerator{testSpec.Definitions, &testFixtures}
 	data, err = generator.Generate(
 		&spec.JSONSchema{Ref: "#/definitions/charge"}, "", nil)
 	assert.Nil(t, err)
@@ -71,7 +71,7 @@ func TestGenerateResponseData(t *testing.T) {
 		data.(map[string]interface{})["customer"])
 
 	// expansion
-	generator = DataGenerator{testSpec.Definitions, testFixtures}
+	generator = DataGenerator{testSpec.Definitions, &testFixtures}
 	data, err = generator.Generate(
 		&spec.JSONSchema{Ref: "#/definitions/charge"},
 		"",
@@ -82,7 +82,7 @@ func TestGenerateResponseData(t *testing.T) {
 		data.(map[string]interface{})["customer"].(map[string]interface{})["id"])
 
 	// bad expansion
-	generator = DataGenerator{testSpec.Definitions, testFixtures}
+	generator = DataGenerator{testSpec.Definitions, &testFixtures}
 	data, err = generator.Generate(
 		&spec.JSONSchema{Ref: "#/definitions/charge"},
 		"",
@@ -90,7 +90,7 @@ func TestGenerateResponseData(t *testing.T) {
 	assert.Equal(t, err, errExpansionNotSupported)
 
 	// bad nested expansion
-	generator = DataGenerator{testSpec.Definitions, testFixtures}
+	generator = DataGenerator{testSpec.Definitions, &testFixtures}
 	data, err = generator.Generate(
 		&spec.JSONSchema{Ref: "#/definitions/charge"},
 		"",
@@ -98,7 +98,7 @@ func TestGenerateResponseData(t *testing.T) {
 	assert.Equal(t, err, errExpansionNotSupported)
 
 	// wildcard expansion
-	generator = DataGenerator{testSpec.Definitions, testFixtures}
+	generator = DataGenerator{testSpec.Definitions, &testFixtures}
 	data, err = generator.Generate(
 		&spec.JSONSchema{Ref: "#/definitions/charge"},
 		"",
@@ -109,7 +109,7 @@ func TestGenerateResponseData(t *testing.T) {
 		data.(map[string]interface{})["customer"].(map[string]interface{})["id"])
 
 	// list
-	generator = DataGenerator{testSpec.Definitions, testFixtures}
+	generator = DataGenerator{testSpec.Definitions, &testFixtures}
 	data, err = generator.Generate(listSchema, "/v1/charges", nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "list", data.(map[string]interface{})["object"])
@@ -161,7 +161,7 @@ func TestGenerateResponseData(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{}, data)
 
 	// error: unhandled JSON schema type
-	generator = DataGenerator{testSpec.Definitions, testFixtures}
+	generator = DataGenerator{testSpec.Definitions, &testFixtures}
 	data, err = generator.Generate(
 		&spec.JSONSchema{Type: []string{"string"}}, "", nil)
 	assert.Equal(t,
@@ -169,7 +169,7 @@ func TestGenerateResponseData(t *testing.T) {
 		err)
 
 	// error: no definition in OpenAPI
-	generator = DataGenerator{testSpec.Definitions, testFixtures}
+	generator = DataGenerator{testSpec.Definitions, &testFixtures}
 	data, err = generator.Generate(
 		&spec.JSONSchema{Ref: "#/definitions/doesnt-exist"}, "", nil)
 	assert.Equal(t,

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+
 	"github.com/stripe/stripe-mock/spec"
 )
 
@@ -8,10 +10,47 @@ var chargeAllMethod *spec.Method
 var chargeCreateMethod *spec.Method
 var chargeDeleteMethod *spec.Method
 var chargeGetMethod *spec.Method
+
+// Try to avoid using the real spec as much as possible because it's more
+// complicated and slower. A test spec is provided below. If you do use it,
+// don't mutate it.
+var realSpec spec.Spec
+var realFixtures spec.Fixtures
+
 var testSpec *spec.Spec
 var testFixtures *spec.Fixtures
 
 func init() {
+	initRealSpec()
+	initTestSpec()
+}
+
+func initRealSpec() {
+	// Load the spec information from go-bindata
+	data, err := Asset("openapi/openapi/spec2.json")
+	if err != nil {
+		panic(err)
+	}
+
+	err = json.Unmarshal(data, &realSpec)
+	if err != nil {
+		panic(err)
+	}
+
+	// And do the same for fixtures
+	data, err = Asset("openapi/openapi/fixtures.json")
+	if err != nil {
+		panic(err)
+	}
+
+	var fixtures spec.Fixtures
+	err = json.Unmarshal(data, &fixtures)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func initTestSpec() {
 	chargeAllMethod = &spec.Method{}
 	chargeCreateMethod = &spec.Method{
 		Parameters: []*spec.Parameter{

--- a/main_test.go
+++ b/main_test.go
@@ -17,8 +17,8 @@ var chargeGetMethod *spec.Method
 var realSpec spec.Spec
 var realFixtures spec.Fixtures
 
-var testSpec *spec.Spec
-var testFixtures *spec.Fixtures
+var testSpec spec.Spec
+var testFixtures spec.Fixtures
 
 func init() {
 	initRealSpec()
@@ -84,7 +84,7 @@ func initTestSpec() {
 	chargeGetMethod = &spec.Method{}
 
 	testFixtures =
-		&spec.Fixtures{
+		spec.Fixtures{
 			Resources: map[spec.ResourceID]interface{}{
 				spec.ResourceID("charge"): map[string]interface{}{
 					"customer": "cus_123",
@@ -94,7 +94,7 @@ func initTestSpec() {
 			},
 		}
 
-	testSpec = &spec.Spec{
+	testSpec = spec.Spec{
 		Definitions: map[string]*spec.JSONSchema{
 			"charge": {
 				Properties: map[string]*spec.JSONSchema{

--- a/server_test.go
+++ b/server_test.go
@@ -199,7 +199,7 @@ func encode64(s string) string {
 }
 
 func getStubServer(t *testing.T) *StubServer {
-	server := &StubServer{spec: testSpec}
+	server := &StubServer{spec: &testSpec}
 	err := server.initializeRouter()
 	assert.NoError(t, err)
 	return server


### PR DESCRIPTION
Previously running concurrency operations against the generator would
result in a panic because it was actually taking maps that it found and
fixtures and mutating them, resulting in concurrent reads and writes.

This patch introduces a fix that copies fixtures that are found in the
decoded set so that each Goroutine is working with a local copy. It also
introduces testing to protect against regressions.

Fixes #10.