### PR TITLE
Coerce integer-indexed maps to slices

### DIFF
--- a/param/coercer/coercer.go
+++ b/param/coercer/coercer.go
@@ -1,6 +1,8 @@
 package coercer
 
 import (
+	"fmt"
+	"regexp"
 	"strconv"
 
 	"github.com/stripe/stripe-mock/spec"
@@ -13,7 +15,7 @@ import (
 // integers.
 //
 // Currently only the coercion of strings to bool and int64 is supported.
-func CoerceParams(schema *spec.JSONSchema, data map[string]interface{}) {
+func CoerceParams(schema *spec.JSONSchema, data map[string]interface{}) error {
 	for key, subSchema := range schema.Properties {
 		val, ok := data[key]
 		if !ok {
@@ -23,6 +25,18 @@ func CoerceParams(schema *spec.JSONSchema, data map[string]interface{}) {
 		valMap, ok := val.(map[string]interface{})
 		if ok {
 			CoerceParams(subSchema, valMap)
+
+			if hasType(subSchema, arrayType) && !hasType(subSchema, objectType) {
+				valSlice, err := parseIntegerIndexedMap(valMap)
+				if err != nil {
+					return err
+				}
+
+				if valSlice != nil {
+					data[key] = valSlice
+				}
+			}
+
 			continue
 		}
 
@@ -52,19 +66,30 @@ func CoerceParams(schema *spec.JSONSchema, data map[string]interface{}) {
 			}
 		}
 	}
+
+	return nil
 }
 
 //
 // ---
 //
 
-// booleanType is the name of the boolean type in a JSON schema.
-const booleanType = "boolean"
+// Various identifiers for types in JSON schema.
+const (
+	arrayType   = "array"
+	booleanType = "boolean"
+	integerType = "integer"
+	numberType  = "number"
+	objectType  = "object"
+)
 
-// integerType is the name of the integer type in a JSON schema.
-const integerType = "integer"
+// maxSliceSize defines a somewhat arbitrary maximum size on an incoming
+// integer-indexed map that we're willing to parse so that we don't run out of
+// memory trying to allocate a slice.
+const maxSliceSize = 1000
 
-const numberType = "number"
+// numberPattern simply checks to see if an input string looks like a number.
+var numberPattern = regexp.MustCompile(`\A\d+\z`)
 
 func hasType(schema *spec.JSONSchema, targetTypeStr string) bool {
 	for _, typeStr := range schema.Type {
@@ -73,4 +98,48 @@ func hasType(schema *spec.JSONSchema, targetTypeStr string) bool {
 		}
 	}
 	return false
+}
+
+// parseIntegerIndexedMap tries to parse a map that has all integer-indexed
+// keys (e.g. { "0": ..., "1": "...", "2": "..." }) as a slice. We only try to
+// do this when we know that the target schema requires an array.
+func parseIntegerIndexedMap(valMap map[string]interface{}) ([]interface{}, error) {
+	allNumberedIndexes := true
+	biggestIndex := 0
+
+	for index := range valMap {
+		matched := numberPattern.MatchString(index)
+		if !matched {
+			allNumberedIndexes = false
+			break
+		}
+
+		valInt, err := strconv.Atoi(index)
+		if err != nil {
+			allNumberedIndexes = false
+			break
+		}
+
+		if valInt > biggestIndex {
+			biggestIndex = valInt
+		}
+	}
+
+	if !allNumberedIndexes {
+		return nil, nil
+	}
+
+	if biggestIndex > maxSliceSize {
+		return nil, fmt.Errorf("Index %v is too large, won't parse as slice", biggestIndex)
+	}
+
+	valSlice := make([]interface{}, biggestIndex+1)
+
+	for index, val := range valMap {
+		// Already checked error above
+		indexInt, _ := strconv.Atoi(index)
+		valSlice[indexInt] = val
+	}
+
+	return valSlice, nil
 }

--- a/server.go
+++ b/server.go
@@ -144,9 +144,15 @@ func (s *StubServer) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	// support validation all verbs, and much more simply.
 	requestSchema := bodyParameterSchema(route.method)
 	if requestSchema != nil {
-		coercer.CoerceParams(requestSchema, requestData)
+		err := coercer.CoerceParams(requestSchema, requestData)
+		if err != nil {
+			fmt.Printf("Coercion error: %v\n", err)
+			responseData := fmt.Sprintf("Request error: %v", err)
+			writeResponse(w, r, start, http.StatusBadRequest, responseData)
+			return
+		}
 
-		err := route.validator.Validate(requestData)
+		err = route.validator.Validate(requestData)
 		if err != nil {
 			fmt.Printf("Validation error: %v\n", err)
 			responseData := fmt.Sprintf("Request error: %v", err)


### PR DESCRIPTION
This is unusual for normal "Rack-style" form encoding, but at Stripe on
some endpoints we allow maps that are indexed with integers to be
changed to arrays in the backend. So for example this:

    myarr[0]=foo

Would be interpreted in the API as:

    ["foo"]

The purpose of this is to be able to use arbitrary indexing to update
only certain items, so this also works:

    myarr[3]=foo

Becomes:

    [nil, nil, nil "foo"]

You can find an example of this in the `items` parameter on create
subscription.

Here we augment the coercer to detect if the target type is `array` and
then try to coerce a map to a slice as long as all its indexes were
strings that looked like integers.

I've added a test suite, but have also verified that this fixes a
failing test in my stripe-go PR that's targeting stripe-mock.

r? @tmaxwell-stripe Mind taking a look? Sorry I know this messes with a PR you
have in flight, but hopefully the rebase won't be too bad. We're basically
adding a function and a couple new const/vars.