### PR TITLE
Fix decoded maps when unmarshaling fixtures from a YAML file

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -148,8 +149,9 @@ func (g *DataGenerator) generateInternal(schema *spec.Schema, requestPath string
 	if schema.Type == "object" && schema.Properties != nil {
 		exampleMap, ok := example.value.(map[string]interface{})
 		if !ok {
-			panic(fmt.Sprintf("%sSchema is an object:\n%s\nBut example is:\n%s",
-				context, schema, example.value))
+			panic(fmt.Sprintf(
+				"%sSchema is an object:\n%s\n\nBut example is (type: %v):\n%s",
+				context, schema, reflect.TypeOf(example.value), example.value))
 		}
 
 		resultMap := make(map[string]interface{})

--- a/main.go
+++ b/main.go
@@ -114,6 +114,15 @@ func getFixtures(fixturesPath string) (*spec.Fixtures, error) {
 
 	if isYAML {
 		err = yaml.Unmarshal(data, &fixtures)
+		if err == nil {
+			// To support boolean keys, the `yaml` package unmarshals maps to
+			// map[interface{}]interface{}. Here we recurse through the result
+			// and change all maps to map[string]interface{} like we would've
+			// gotten from `json`.
+			for k, v := range fixtures.Resources {
+				fixtures.Resources[k] = stringifyKeysMapValue(v)
+			}
+		}
 	} else {
 		err = json.Unmarshal(data, &fixtures)
 	}

--- a/mapstr.go
+++ b/mapstr.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+)
+
+// stringifyKeysMapValue recurses into v and changes all instances of
+// map[interface{}]interface{} to map[string]interface{}. This is useful to
+// work around the impedence mismatch between JSON and YAML unmarshaling that's
+// described here:
+//
+// https://github.com/go-yaml/yaml/issues/139
+func stringifyKeysMapValue(v interface{}) interface{} {
+	switch v := v.(type) {
+	case []interface{}:
+		return stringifyKeysInterfaceArray(v)
+	case map[interface{}]interface{}:
+		return stringifyKeysInterfaceMap(v)
+	default:
+		return v
+	}
+}
+
+//
+// helpers
+//
+
+func stringifyKeysInterfaceArray(in []interface{}) []interface{} {
+	res := make([]interface{}, len(in))
+	for i, v := range in {
+		res[i] = stringifyKeysMapValue(v)
+	}
+	return res
+}
+
+func stringifyKeysInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
+	res := make(map[string]interface{})
+	for k, v := range in {
+		res[fmt.Sprintf("%v", k)] = stringifyKeysMapValue(v)
+	}
+	return res
+}

--- a/mapstr.go
+++ b/mapstr.go
@@ -36,7 +36,11 @@ func stringifyKeysInterfaceArray(in []interface{}) []interface{} {
 func stringifyKeysInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
 	res := make(map[string]interface{})
 	for k, v := range in {
-		res[fmt.Sprintf("%v", k)] = stringifyKeysMapValue(v)
+		kStr, ok := k.(string)
+		if !ok {
+			panic(fmt.Sprintf("Expected all keys in maps to be strings. Got: %v", k))
+		}
+		res[kStr] = stringifyKeysMapValue(v)
 	}
 	return res
 }

--- a/mapstr_test.go
+++ b/mapstr_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestStringifyKeysMapValue(t *testing.T) {
+	assert.Equal(t,
+		map[string]interface{}{
+			"arrkey": []interface{}{
+				123,
+				map[string]interface{}{
+					"intkey": 123,
+				},
+			},
+			"boolkey": true,
+			"intkey":  123,
+			"mapkey": map[string]interface{}{
+				"intkey": 123,
+			},
+		},
+		stringifyKeysMapValue(map[interface{}]interface{}{
+			"arrkey": []interface{}{
+				123,
+				map[interface{}]interface{}{
+					"intkey": 123,
+				},
+			},
+			"boolkey": true,
+			"intkey":  123,
+			"mapkey": map[interface{}]interface{}{
+				"intkey": 123,
+			},
+		}),
+	)
+}


### PR DESCRIPTION
As shown in #22, when we try to unmarshal fixtures from a YAML file, we
end up with a crash in the generator due to a type mismatch.

This turns out to be because of [1]. Because YAML technically supports
boolean keys, the YAML library unmarshals to maps in a way to handle
them (`map[interface{}]interface{}`), even if it's not suitable for most
users (the issue strongly suggests that a lot of people would like
`map[string]interface{}`).

Here we work around the problem by post-processing fixtures that we've
loaded via YAML by recursing through and changing all instances of
`map[interface{}]interface{}` to `map[string]interface{}`. I've added a
few basic tests, but also tested that the call reported in #22 now works
as expected.

Fixes #22.

[1] https://github.com/go-yaml/yaml/issues/139

r? @tmaxwell-stripe