### PR TITLE
Define a StripeError struct and use this on all API errors

### DIFF
--- a/server.go
+++ b/server.go
@@ -114,6 +114,9 @@ func (s *StubServer) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Every response needs a Request-Id header except the invalid authorization
+	w.Header().Set("Request-Id", "req_123")
+
 	route := s.routeRequest(r)
 	if route == nil {
 		stripeError.ErrorInfo.Message = fmt.Sprintf(invalidRoute,

--- a/server.go
+++ b/server.go
@@ -122,6 +122,7 @@ func (s *StubServer) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 	response, ok := route.operation.Responses["200"]
 	if !ok {
+		fmt.Printf("Couldn't find 200 response in spec\n")
 		writeResponse(w, r, start, http.StatusInternalServerError,
 			createInternalServerError())
 		return

--- a/server.go
+++ b/server.go
@@ -31,12 +31,13 @@ const (
 )
 
 type ErrorInfo struct {
-	Type    string `json:"type"`
-	Message string `json:"message"`
 }
 
 type ResponseError struct {
-	ErrorInfo ErrorInfo `json:"error"`
+	ErrorInfo struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	} `json:"error"`
 }
 
 // ExpansionLevel represents expansions on a single "level" of resource. It may
@@ -436,14 +437,15 @@ func validateAuth(auth string) bool {
 
 // This creates a Stripe error to return in case of API errors.
 func createStripeError(errorType string, errorMessage string) *ResponseError {
-	stripeError := &ResponseError{
-		ErrorInfo: ErrorInfo{
+	return &ResponseError{
+		ErrorInfo: struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		}{
 			Message: errorMessage,
 			Type:    errorType,
 		},
 	}
-
-	return stripeError
 }
 
 // Helper to create an internal server error for API issues.

--- a/server_test.go
+++ b/server_test.go
@@ -34,21 +34,21 @@ func TestStubServerError(t *testing.T) {
 	var data map[string]interface{}
 	err := json.Unmarshal(body, &data)
 	assert.NoError(t, err)
-	errorInfo, present := data["error"].(map[string]interface{})
-	assert.True(t, present)
-	errorType, present := errorInfo["type"]
+	errorInfo, ok := data["error"].(map[string]interface{})
+	assert.True(t, ok)
+	errorType, ok := errorInfo["type"]
 	assert.Equal(t, errorType, "invalid_request_error")
-	assert.True(t, present)
-	_, present = errorInfo["message"]
-	assert.True(t, present)
+	assert.True(t, ok)
+	_, ok = errorInfo["message"]
+	assert.True(t, ok)
 }
 
 func TestStubServer_SetsSpecialHeaders(t *testing.T) {
 	resp, _ := sendRequest(t, "POST", "/", "", nil)
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	assert.Equal(t, version, resp.Header.Get("Stripe-Mock-Version"))
-	_, present := resp.Header["Request-Id"]
-	assert.False(t, present)
+	_, ok := resp.Header["Request-Id"]
+	assert.False(t, ok)
 
 	resp, _ = sendRequest(t, "POST", "/", "", getDefaultHeaders())
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)

--- a/server_test.go
+++ b/server_test.go
@@ -48,6 +48,13 @@ func TestStubServer_SetsSpecialHeaders(t *testing.T) {
 	resp, _ := sendRequest(t, "POST", "/", "", nil)
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	assert.Equal(t, version, resp.Header.Get("Stripe-Mock-Version"))
+	_, present := resp.Header["Request-Id"]
+	assert.False(t, present)
+
+	resp, _ = sendRequest(t, "POST", "/", "", getDefaultHeaders())
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, version, resp.Header.Get("Stripe-Mock-Version"))
+	assert.Equal(t, "req_123", resp.Header.Get("Request-Id"))
 }
 
 func TestStubServer_ParameterValidation(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -18,7 +18,6 @@ import (
 func TestStubServer(t *testing.T) {
 	resp, body := sendRequest(t, "POST", "/v1/charges",
 		"amount=123&currency=usd", getDefaultHeaders())
-
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	var data map[string]interface{}
@@ -26,14 +25,14 @@ func TestStubServer(t *testing.T) {
 	assert.NoError(t, err)
 	_, ok := data["id"]
 	assert.True(t, ok)
+}
 
-	// Ensure error response has the correct shape
-
-	resp, body = sendRequest(t, "GET", "/a", "", nil)
-
+func TestStubServerError(t *testing.T) {
+	resp, body := sendRequest(t, "GET", "/a", "", nil)
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
-	err = json.Unmarshal(body, &data)
+	var data map[string]interface{}
+	err := json.Unmarshal(body, &data)
 	assert.NoError(t, err)
 	errorInfo, present := data["error"].(map[string]interface{})
 	assert.True(t, present)


### PR DESCRIPTION
This lets stripe-mock return API errors as a JSON payload instead of just the error message.

This fixes https://github.com/stripe/stripe-mock/issues/31 and lets us use stripe-mock better in stripe-python tests for https://github.com/stripe/stripe-python/pull/367

It also ensures that `Request-Id` is properly returned as a header on all requests except the authentication error ones.