### PR TITLE
Always print the stripe-mock version

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,8 +43,8 @@ func main() {
 	flag.BoolVar(&showVersion, "version", false, "Show version")
 	flag.Parse()
 
+	fmt.Printf("stripe-mock %s\n", version)
 	if showVersion || len(flag.Args()) == 1 && flag.Arg(0) == "version" {
-		fmt.Printf("%s\n", version)
 		return
 	}
 


### PR DESCRIPTION
I've found it a bit confusing, during stripe-mock version changes, to know what version I'm running. I discovered that I can run `stripe-mock --version` to see what version I have, but it'd be nice if I never had to do that. This (maybe contentious) change will make stripe-mock emit its version each time it runs.

r? @stripe/api-libraries 