### PR TITLE
Send valid path to generator while running test suite

### DIFF
--- a/generator_test.go
+++ b/generator_test.go
@@ -177,7 +177,7 @@ func TestValidFixtures(t *testing.T) {
 
 // Tests that DataGenerator can generate an example of the given schema, and
 // that the example validates against the schema correctly
-func testCanGenerate(t *testing.T, schema *spec.Schema, expand bool) {
+func testCanGenerate(t *testing.T, path spec.Path, schema *spec.Schema, expand bool) {
 	assert.NotNil(t, schema)
 
 	generator := DataGenerator{
@@ -196,7 +196,7 @@ func testCanGenerate(t *testing.T, schema *spec.Schema, expand bool) {
 	var example interface{}
 	var err error
 	assert.NotPanics(t, func() {
-		example, err = generator.Generate(schema, "<test request path>", expansions)
+		example, err = generator.Generate(schema, string(path), expansions)
 	})
 	assert.NoError(t, err)
 
@@ -218,7 +218,7 @@ func TestResourcesCanBeGenerated(t *testing.T) {
 			schema := operation.Responses[spec.StatusCode("200")].Content["application/json"].Schema
 			t.Run(
 				fmt.Sprintf("%s %s (without expansions)", method, url),
-				func(t2 *testing.T) { testCanGenerate(t2, schema, false) },
+				func(t2 *testing.T) { testCanGenerate(t2, url, schema, false) },
 			)
 		}
 	}
@@ -232,7 +232,7 @@ func TestResourcesCanBeGeneratedAndExpanded(t *testing.T) {
 			schema := operation.Responses[spec.StatusCode("200")].Content["application/json"].Schema
 			t.Run(
 				fmt.Sprintf("%s %s (with expansions)", method, url),
-				func(t2 *testing.T) { testCanGenerate(t2, schema, true) },
+				func(t2 *testing.T) { testCanGenerate(t2, url, schema, true) },
 			)
 		}
 	}


### PR DESCRIPTION
So I couldn't figure out what exactly changed here, but as reported in
our channel yesterday, `stripe-mock`'s test suite fails on the latest
version of the OpenAPI spec.

The reason is that when generating list resources, we're currently
filling in `url` with the dud string `<test request path>`, and doing so
causes the generated resource to fail to validate because that string is
not in the OpenAPI spec's `enum` set for `url`.

Here we resolve the problem by plumbing through each URL's path from the
ingested OpenAPI spec and sending it onto the generator.

This doesn't quite fix the problems with the latest OpenAPI though —
there's at least one more case of an invalid fixture which I'm trying to
resolve separately.

r? @tmaxwell-stripe
cc @alexander-stripe
cc @stripe/api-libraries