### PR TITLE
Fix link to `stripe-mock` homepage

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -11,7 +11,7 @@ brew:
   github:
     owner: stripe
     name: homebrew-stripe-mock
-  homepage: "https://github.com.com/stripe/stripe-mock"
+  homepage: "https://github.com/stripe/stripe-mock"
   description: "stripe-mock is a mock HTTP server that responds like the real Stripe API. It can be used instead of Stripe's testmode to make test suites integrating with Stripe faster and less brittle."
 
   plist: |


### PR DESCRIPTION
The old link accidentally includes `.com.com`.

Fixes: https://github.com/stripe/homebrew-stripe-mock/issues/3