### PR TITLE
Reflect an object's primary ID from a path back in the response

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -6,10 +6,13 @@ import (
 	"github.com/stripe/stripe-mock/spec"
 )
 
+var applicationFeeRefundCreateMethod *spec.Operation
+var applicationFeeRefundGetMethod *spec.Operation
 var chargeAllMethod *spec.Operation
 var chargeCreateMethod *spec.Operation
 var chargeDeleteMethod *spec.Operation
 var chargeGetMethod *spec.Operation
+var invoicePayMethod *spec.Operation
 
 // Try to avoid using the real spec as much as possible because it's more
 // complicated and slower. A test spec is provided below. If you do use it,
@@ -54,6 +57,11 @@ func initRealSpec() {
 }
 
 func initTestSpec() {
+	// These are basically here to give us a URL to test against that has
+	// multiple parameters in it.
+	applicationFeeRefundCreateMethod = &spec.Operation{}
+	applicationFeeRefundGetMethod = &spec.Operation{}
+
 	chargeAllMethod = &spec.Operation{}
 	chargeCreateMethod = &spec.Operation{
 		RequestBody: &spec.RequestBody{
@@ -84,6 +92,10 @@ func initTestSpec() {
 	}
 	chargeDeleteMethod = &spec.Operation{}
 	chargeGetMethod = &spec.Operation{}
+
+	// Here so we can test the relatively rare "action" operations (e.g.,
+	// `POST` to `/pay` on an invoice).
+	invoicePayMethod = &spec.Operation{}
 
 	testFixtures =
 		spec.Fixtures{
@@ -127,6 +139,12 @@ func initTestSpec() {
 			},
 		},
 		Paths: map[spec.Path]map[spec.HTTPVerb]*spec.Operation{
+			spec.Path("/v1/application_fees/{fee}/refunds"): {
+				"get": applicationFeeRefundCreateMethod,
+			},
+			spec.Path("/v1/application_fees/{fee}/refunds/{id}"): {
+				"get": applicationFeeRefundGetMethod,
+			},
 			spec.Path("/v1/charges"): {
 				"get":  chargeAllMethod,
 				"post": chargeCreateMethod,
@@ -134,6 +152,9 @@ func initTestSpec() {
 			spec.Path("/v1/charges/{id}"): {
 				"get":    chargeGetMethod,
 				"delete": chargeDeleteMethod,
+			},
+			spec.Path("/v1/invoices/{id}/pay"): {
+				"post": invoicePayMethod,
 			},
 		},
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -76,31 +76,61 @@ func TestStubServer_FormatsForCurl(t *testing.T) {
 
 func TestStubServer_RoutesRequest(t *testing.T) {
 	server := getStubServer(t)
+	var id *string
 	var route *stubServerRoute
 
-	route = server.routeRequest(
+	route, id = server.routeRequest(
 		&http.Request{Method: "GET", URL: &url.URL{Path: "/v1/charges"}})
 	assert.NotNil(t, route)
 	assert.Equal(t, chargeAllMethod, route.operation)
+	assert.Nil(t, id)
 
-	route = server.routeRequest(
+	route, id = server.routeRequest(
 		&http.Request{Method: "POST", URL: &url.URL{Path: "/v1/charges"}})
 	assert.NotNil(t, route)
 	assert.Equal(t, chargeCreateMethod, route.operation)
+	assert.Nil(t, id)
 
-	route = server.routeRequest(
+	route, id = server.routeRequest(
 		&http.Request{Method: "GET", URL: &url.URL{Path: "/v1/charges/ch_123"}})
 	assert.NotNil(t, route)
 	assert.Equal(t, chargeGetMethod, route.operation)
+	assert.Equal(t, "ch_123", *id)
 
-	route = server.routeRequest(
+	route, id = server.routeRequest(
 		&http.Request{Method: "DELETE", URL: &url.URL{Path: "/v1/charges/ch_123"}})
 	assert.NotNil(t, route)
 	assert.Equal(t, chargeDeleteMethod, route.operation)
+	assert.Equal(t, "ch_123", *id)
 
-	route = server.routeRequest(
+	route, id = server.routeRequest(
 		&http.Request{Method: "GET", URL: &url.URL{Path: "/v1/doesnt-exist"}})
 	assert.Equal(t, (*stubServerRoute)(nil), route)
+	assert.Nil(t, id)
+
+	// Route with a parameter, but not an object's primary ID
+	route, id = server.routeRequest(
+		&http.Request{Method: "POST",
+			URL: &url.URL{Path: "/v1/invoices/in_123/pay"}})
+	assert.NotNil(t, route)
+	assert.Equal(t, chargeDeleteMethod, route.operation)
+	assert.Equal(t, "in_123", *id)
+
+	// Route with a parameter, but not an object's primary ID
+	route, id = server.routeRequest(
+		&http.Request{Method: "GET",
+			URL: &url.URL{Path: "/v1/application_fees/fee_123/refunds"}})
+	assert.NotNil(t, route)
+	assert.Equal(t, invoicePayMethod, route.operation)
+	assert.Nil(t, id)
+
+	// Route with multiple parameters in its URL
+	route, id = server.routeRequest(
+		&http.Request{Method: "GET",
+			URL: &url.URL{Path: "/v1/application_fees/fee_123/refunds/fr_123"}})
+	assert.NotNil(t, route)
+	assert.Equal(t, chargeDeleteMethod, route.operation)
+	assert.Equal(t, "fr_123", *id)
 }
 
 // ---


### PR DESCRIPTION
When requesting a path from `stripe-mock` with an object's primary ID in
the URL:

```
GET /v1/charges/ch_idFromURL
```

Previously, we'd return the ID from the bundled fixtures. This patch
changes the behavior to try and detect when the path contains an
object's primary ID and reflect that back into the respond instead:

```
{
    "id": "ch_idFromURL",
}
```

(Previously, this would have been `ch_123` or whatever the fixtures
contained.)

We also tweak things in a few other places for consistency. If we find a
string value in our generated response with the same value as the ID we
replaced, we replace it as well. This allows an embedded resource with
an ID field that references its parent to reference it with a sane ID
(e.g., the `charge` field on a refund that's embedded in a charge's
`refunds` sublist).

We also modify URLs in embedded sublists to contain the right ID. e.g.,

```
{
    "url": "/v1/charges/ch_idFromURL"
}
```

This is necessary because those URLs are used by our client libraries to
determine where they should make calls to (e.g., in `stripe-ruby`
calling `charge.refunds.create(...)` uses that `url` values to know
where to post).

All of this is designed to get our test suite working again with the
latest OpenAPI fixtures. In particular, this will allow us to return the
right `id` for any deleted object, which will allow `stripe-ruby`'s web
mock checks to pass correctly.

r? @tmaxwell
cc @stripe/api-libraries