### PR TITLE
Fix non-deterministic test

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -624,6 +624,11 @@ func propertyNames(schema *spec.Schema) string {
 	for name := range schema.Properties {
 		names = append(names, name)
 	}
+
+	// Sort just so we can have stable output to test against (the order at
+	// which keys will be iterated in the map is undefined).
+	sort.Strings(names)
+
 	return strings.Join(names, ", ")
 }
 

--- a/generator_test.go
+++ b/generator_test.go
@@ -358,7 +358,7 @@ func TestGenerateSyntheticFixture(t *testing.T) {
 }
 
 func TestPropertyNames(t *testing.T) {
-	assert.Equal(t, "foo, bar", propertyNames(&spec.Schema{
+	assert.Equal(t, "bar, foo", propertyNames(&spec.Schema{
 		Properties: map[string]*spec.Schema{
 			"foo": nil,
 			"bar": nil,


### PR DESCRIPTION
I recently introduced a test that checks its results against a value
generated by iterating a map. In Go, the order with which a map is
iterated is not guaranteed, and so the test will occasionally fail as
the map is iterated in an order contrary to its insertion order.

This patch sorts the output slice before joining it, thereby fixing the
non-determinism. This is a case that's only occasionally hit and only in
verbose mode, so the performance implications are miniscule.