### PR TITLE
Implement "advanced" path parameter response reflection

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -80,61 +80,84 @@ func TestStubServer_FormatsForCurl(t *testing.T) {
 
 func TestStubServer_RoutesRequest(t *testing.T) {
 	server := getStubServer(t)
-	var id *string
-	var route *stubServerRoute
 
-	route, id = server.routeRequest(
-		&http.Request{Method: "GET", URL: &url.URL{Path: "/v1/charges"}})
-	assert.NotNil(t, route)
-	assert.Equal(t, chargeAllMethod, route.operation)
-	assert.Nil(t, id)
+	{
+		route, pathParams := server.routeRequest(
+			&http.Request{Method: "GET", URL: &url.URL{Path: "/v1/charges"}})
+		assert.NotNil(t, route)
+		assert.Equal(t, chargeAllMethod, route.operation)
+		assert.Nil(t, pathParams)
+	}
 
-	route, id = server.routeRequest(
-		&http.Request{Method: "POST", URL: &url.URL{Path: "/v1/charges"}})
-	assert.NotNil(t, route)
-	assert.Equal(t, chargeCreateMethod, route.operation)
-	assert.Nil(t, id)
+	{
+		route, pathParams := server.routeRequest(
+			&http.Request{Method: "POST", URL: &url.URL{Path: "/v1/charges"}})
+		assert.NotNil(t, route)
+		assert.Equal(t, chargeCreateMethod, route.operation)
+		assert.Nil(t, pathParams)
+	}
 
-	route, id = server.routeRequest(
-		&http.Request{Method: "GET", URL: &url.URL{Path: "/v1/charges/ch_123"}})
-	assert.NotNil(t, route)
-	assert.Equal(t, chargeGetMethod, route.operation)
-	assert.Equal(t, "ch_123", *id)
+	{
+		route, pathParams := server.routeRequest(
+			&http.Request{Method: "GET", URL: &url.URL{Path: "/v1/charges/ch_123"}})
+		assert.NotNil(t, route)
+		assert.Equal(t, chargeGetMethod, route.operation)
+		assert.Equal(t, "ch_123", *(*pathParams).PrimaryID)
+		assert.Equal(t, []*PathParamsSecondaryID(nil), (*pathParams).SecondaryIDs)
+	}
 
-	route, id = server.routeRequest(
-		&http.Request{Method: "DELETE", URL: &url.URL{Path: "/v1/charges/ch_123"}})
-	assert.NotNil(t, route)
-	assert.Equal(t, chargeDeleteMethod, route.operation)
-	assert.Equal(t, "ch_123", *id)
+	{
+		route, pathParams := server.routeRequest(
+			&http.Request{Method: "DELETE", URL: &url.URL{Path: "/v1/charges/ch_123"}})
+		assert.NotNil(t, route)
+		assert.Equal(t, chargeDeleteMethod, route.operation)
+		assert.Equal(t, "ch_123", *(*pathParams).PrimaryID)
+		assert.Equal(t, []*PathParamsSecondaryID(nil), (*pathParams).SecondaryIDs)
+	}
 
-	route, id = server.routeRequest(
-		&http.Request{Method: "GET", URL: &url.URL{Path: "/v1/doesnt-exist"}})
-	assert.Equal(t, (*stubServerRoute)(nil), route)
-	assert.Nil(t, id)
+	{
+		route, pathParams := server.routeRequest(
+			&http.Request{Method: "GET", URL: &url.URL{Path: "/v1/doesnt-exist"}})
+		assert.Equal(t, (*stubServerRoute)(nil), route)
+		assert.Nil(t, pathParams)
+	}
 
 	// Route with a parameter, but not an object's primary ID
-	route, id = server.routeRequest(
-		&http.Request{Method: "POST",
-			URL: &url.URL{Path: "/v1/invoices/in_123/pay"}})
-	assert.NotNil(t, route)
-	assert.Equal(t, chargeDeleteMethod, route.operation)
-	assert.Equal(t, "in_123", *id)
+	{
+		route, pathParams := server.routeRequest(
+			&http.Request{Method: "POST",
+				URL: &url.URL{Path: "/v1/invoices/in_123/pay"}})
+		assert.NotNil(t, route)
+		assert.Equal(t, chargeDeleteMethod, route.operation)
+		assert.Equal(t, "in_123", *(*pathParams).PrimaryID)
+		assert.Equal(t, []*PathParamsSecondaryID(nil), (*pathParams).SecondaryIDs)
+	}
 
 	// Route with a parameter, but not an object's primary ID
-	route, id = server.routeRequest(
-		&http.Request{Method: "GET",
-			URL: &url.URL{Path: "/v1/application_fees/fee_123/refunds"}})
-	assert.NotNil(t, route)
-	assert.Equal(t, invoicePayMethod, route.operation)
-	assert.Nil(t, id)
+	{
+		route, pathParams := server.routeRequest(
+			&http.Request{Method: "GET",
+				URL: &url.URL{Path: "/v1/application_fees/fee_123/refunds"}})
+		assert.NotNil(t, route)
+		assert.Equal(t, invoicePayMethod, route.operation)
+		assert.Equal(t, (*string)(nil), (*pathParams).PrimaryID)
+		assert.Equal(t, 1, len((*pathParams).SecondaryIDs))
+		assert.Equal(t, "fee_123", (*pathParams).SecondaryIDs[0].ID)
+		assert.Equal(t, "fee", (*pathParams).SecondaryIDs[0].Name)
+	}
 
 	// Route with multiple parameters in its URL
-	route, id = server.routeRequest(
-		&http.Request{Method: "GET",
-			URL: &url.URL{Path: "/v1/application_fees/fee_123/refunds/fr_123"}})
-	assert.NotNil(t, route)
-	assert.Equal(t, chargeDeleteMethod, route.operation)
-	assert.Equal(t, "fr_123", *id)
+	{
+		route, pathParams := server.routeRequest(
+			&http.Request{Method: "GET",
+				URL: &url.URL{Path: "/v1/application_fees/fee_123/refunds/fr_123"}})
+		assert.NotNil(t, route)
+		assert.Equal(t, chargeDeleteMethod, route.operation)
+		assert.Equal(t, "fr_123", *(*pathParams).PrimaryID)
+		assert.Equal(t, 1, len((*pathParams).SecondaryIDs))
+		assert.Equal(t, "fee_123", (*pathParams).SecondaryIDs[0].ID)
+		assert.Equal(t, "fee", (*pathParams).SecondaryIDs[0].Name)
+	}
 }
 
 func TestGetValidator(t *testing.T) {


### PR DESCRIPTION
Implement "advanced" path parameter response reflection

Builds on reflecting URL parameters as introduced in #59 to also support
reflecting parameters beyond just the object's primary ID. More
concretely, if we have a path like this:

	/application_fees/fee_123/refunds/re_123

Before we'd just reflect the last part in (`re_123`), but here we now
reflect the parent object in as well (`fee_123`).

The one major caveat to this is that currently our query parameters are
not very introspectable in that we don't really know what kind of object
`fee_123` is supposed to be. To that end, we use the name of the
parameter (in this case `fee`) and compare that it against two places
to see if it's likely a referencing this object:

	* A fixture's `object` value.
	* The name of the key containing an ID value of subobject.

This will work for some objects, but I'm probably going to go through
and either (1) do a pass in the backend to correctly name parameters, or
(2) implement a lookup table in `stripe-mock` to get this working 100%.

Does most of the work to address #61.