### PR TITLE
Support primitives in an `anyOf` from the parameters coercer

### DIFF
--- a/param/coercer/coercer_test.go
+++ b/param/coercer/coercer_test.go
@@ -7,6 +7,24 @@ import (
 	"github.com/stripe/stripe-mock/spec"
 )
 
+func TestCoerceParams_AnyOfCoercion(t *testing.T) {
+	schema := &spec.Schema{Properties: map[string]*spec.Schema{
+		"objectorintkey": {
+			AnyOf: []*spec.Schema{
+				{Type: objectType},
+				{Type: integerType},
+			},
+		},
+	}}
+	data := map[string]interface{}{
+		"objectorintkey": "123",
+	}
+
+	err := CoerceParams(schema, data)
+	assert.NoError(t, err)
+	assert.Equal(t, 123, data["objectorintkey"])
+}
+
 func TestCoerceParams_ArrayCoercion(t *testing.T) {
 	// Array of primitive values
 	{


### PR DESCRIPTION
I was running `stripe-ruby`'s test suite against a recent version of the
OpenAPI, and noticed that unfortunately, recent updates have broken it.
In particular, the new tiers feature under plan creation now has a
primitive type nested in an `anyOf`, which is something that we've never
had to handle before:

``` yaml
up_to:
  anyOf:
  - enum:
    - inf
    type: string
  - type: integer
```

`stripe-ruby` tries to run this against it:

``` ruby
plan = Stripe::Plan.create(
  ...
  tiers: [{ up_to: 100, amount: 1000 }, { up_to: "inf", amount: 2000 }]
)
```

What's supposed to happen is that "100" is coerced to an integer, but it's not
because the integer possibility is nested in an `anyOf` as seen above.

This patch addresses the problem by allowing the coercer to recurse into an
`anyOf` to try coercion. It's able to theoretically handle any number of
`anyOf` possibilities, and will dutifully try coercing each one until it finds
a coercable type (or it doesn't, which is okay).

I've run `stripe-ruby`'s test suite against a version of `stripe-mock` with
this patch in it to verify that it works.

r? @tmaxwell-stripe  (This one should be a little simpler to review than the other PR.)
cc @stripe/api-libraries