### PR TITLE
Validate `multipart/form-data` + error on mismatched media types

### DIFF
--- a/param/form/form.go
+++ b/param/form/form.go
@@ -1,0 +1,15 @@
+// Package form is a small package used to hold a few types common to the param
+// package so that we don't have import cycles.
+package form
+
+//
+// Public types
+//
+
+// FormPair is a key/value pair as extracted from a form-encoded string. For
+// example, "a=b" is the pair [a, b].
+type FormPair [2]string
+
+// FormValues is a full slice of all the key/value pairs from a form-encoded
+// string.
+type FormValues []FormPair

--- a/param/form/form_test.go
+++ b/param/form/form_test.go
@@ -1,0 +1,4 @@
+package form
+
+// Add tests here if the package is ever expanded beyond its currently trivial
+// state.

--- a/param/nestedtypeassembler/nestedtypeassembler.go
+++ b/param/nestedtypeassembler/nestedtypeassembler.go
@@ -1,0 +1,286 @@
+// Package nestedtypeassembler takes a collection of FormPair tuples and uses
+// them to construct more complex data types using "Rack-style" conventions for
+// arrays and maps with a few small Stripe-specific tweaks.
+//
+// When processing a request, data should first be parsed from the query, form,
+// or multipart form, handed off to this package for assembly, then passed on
+// the coercer to coerce string to other expected types.
+package nestedtypeassembler
+
+import (
+	"fmt"
+
+	"github.com/stripe/stripe-mock/param/form"
+)
+
+//
+// Public functions
+//
+
+func AssembleParams(form form.FormValues) (map[string]interface{}, error) {
+	params := make(map[string]interface{})
+
+	for _, pair := range form {
+		key := pair[0]
+		value := pair[1]
+
+		keyParts := parseKey(key)
+
+		if len(keyParts) == 0 {
+			continue
+		}
+
+		rawkeyPart := keyParts[0]
+		if rawkeyPart.KeyType() != keyTypeRaw {
+			return nil, fmt.Errorf(`Invalid key "%v". Keys must start with a name.`, key)
+		}
+
+		pairParams, err := buildParamStructure(rawkeyPart.Content(), keyParts[1:], value)
+		if err != nil {
+			return nil, err
+		}
+
+		//fmt.Printf("new params = %+v\n", pairParams)
+		mergeMapsRecursive(params, pairParams)
+		//fmt.Printf("merge result = %+v\n\n", params)
+	}
+
+	return params, nil
+}
+
+//
+// Private constants
+//
+
+const (
+	keyTypeArray = iota
+	keyTypeMap
+	keyTypeRaw
+)
+
+//
+// Private types
+//
+
+// keyPart is an interface for a struct that represents a "part" of a parameter
+// key. For example, we might say that in `obj[]` the `[]` is an array part.
+type keyPart interface {
+	KeyType() int
+	Content() string
+}
+
+// keyType represents an array part of a parameter key, like the `[]` in
+// `obj[][foo]`.
+type keyArray struct {
+}
+
+func (k *keyArray) KeyType() int {
+	return keyTypeArray
+}
+
+func (k *keyArray) Content() string {
+	panic("keyArray doesn't support Content")
+}
+
+// keyMap represents a map part of a parameter key, like the `[foo]` in
+// `obj[][foo]`.
+type keyMap struct {
+	content string
+}
+
+func (k *keyMap) KeyType() int {
+	return keyTypeMap
+}
+
+func (k *keyMap) Content() string {
+	return k.content
+}
+
+// keyRaw represents the raw name of a parameter key, like the `obj` in
+// `obj[][foo]`.
+type keyRaw struct {
+	content string
+}
+
+func (k *keyRaw) KeyType() int {
+	return keyTypeRaw
+}
+
+func (k *keyRaw) Content() string {
+	return k.content
+}
+
+//
+// Private functions
+//
+
+func parseKey(key string) []keyPart {
+	var keyParts []keyPart
+	var c rune
+	var i int
+	var mapContent []rune
+	var rawContent []rune
+
+	keyRunes := []rune(key)
+
+raw:
+	if i >= len(keyRunes) {
+		goto finished
+	}
+
+	c = keyRunes[i]
+	i++
+
+	if c == '[' {
+		if len(rawContent) > 0 {
+			keyParts = append(keyParts, &keyRaw{content: string(rawContent)})
+			rawContent = nil
+		}
+
+		goto inMapOrArray
+	}
+
+	rawContent = append(rawContent, c)
+	goto raw
+
+inMapOrArray:
+	if i >= len(keyRunes) {
+		goto finished
+	}
+
+	c = keyRunes[i]
+	i++
+
+	if c == ']' {
+		keyParts = append(keyParts, &keyArray{})
+		goto raw
+	}
+
+	mapContent = append(mapContent, c)
+
+	// Fall through to inMap
+
+inMap:
+	if i >= len(keyRunes) {
+		goto finished
+	}
+
+	c = keyRunes[i]
+	i++
+
+	if c == ']' {
+		keyParts = append(keyParts, &keyMap{content: string(mapContent)})
+		mapContent = nil
+		goto raw
+	}
+
+	mapContent = append(mapContent, c)
+	goto inMap
+
+finished:
+	if len(keyParts) == 0 && len(rawContent) > 0 {
+		keyParts = append(keyParts, &keyRaw{content: string(rawContent)})
+		rawContent = nil
+	}
+
+	return keyParts
+}
+
+func buildParamStructure(key string, parts []keyPart, value string) (map[string]interface{}, error) {
+	params := make(map[string]interface{})
+
+	if len(parts) == 0 {
+		params[key] = value
+		return params, nil
+	}
+
+	part := parts[0]
+
+	switch part.KeyType() {
+	case keyTypeArray:
+		subParams, err := buildParamStructure("dummy", parts[1:], value)
+		if err != nil {
+			return nil, err
+		}
+		params[key] = []interface{}{subParams["dummy"]}
+
+	case keyTypeMap:
+		subParams, err := buildParamStructure(part.Content(), parts[1:], value)
+		if err != nil {
+			return nil, err
+		}
+		params[key] = subParams
+
+	default:
+		return nil, fmt.Errorf("Invalid key. Raw content can't be mixed in after arrays and maps.")
+	}
+
+	return params, nil
+}
+
+func maybeCollapseArrays(arr1, arr2 []interface{}) bool {
+	//fmt.Printf("maybe collapse arrays %+v %+v\n", arr1, arr2)
+
+	if len(arr2) != 1 {
+		panic("Expected array with length exactly 1")
+	}
+
+	// arr1's merge candidate is its last element only
+	arr1Map, ok := arr1[len(arr1)-1].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	arr2Map, ok := arr2[0].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	// If any of the keys in arr2's map are already in arr1's map, then don't
+	// merge we consider this a new map.
+	for key := range arr2Map {
+		val, ok := arr1Map[key]
+		if ok {
+			_, okArr := val.([]interface{})
+			_, okMap := val.(map[string]interface{})
+			if !okArr && !okMap {
+				return false
+			}
+		}
+	}
+
+	mergeMapsRecursive(arr1Map, arr2Map)
+	return true
+}
+
+func mergeMapsRecursive(map1, map2 map[string]interface{}) {
+	for key, val2 := range map2 {
+		val1, ok := map1[key]
+		if ok {
+			val1Map, ok := val1.(map[string]interface{})
+			if ok {
+				val2Map, ok := val2.(map[string]interface{})
+				if ok {
+					mergeMapsRecursive(val1Map, val2Map)
+					continue
+				}
+			}
+
+			val1Arr, ok := val1.([]interface{})
+			if ok {
+				val2Arr, ok := val2.([]interface{})
+				if ok {
+					ok := maybeCollapseArrays(val1Arr, val2Arr)
+					if !ok {
+						map1[key] = append(val1Arr, val2Arr...)
+					}
+					continue
+				}
+			}
+		}
+
+		// If not an array or map, or we couldn't reconcile types between the
+		// two maps, simply set the key in map1 to the value from map2.
+		map1[key] = val2
+	}
+}

--- a/param/nestedtypeassembler/nestedtypeassembler_test.go
+++ b/param/nestedtypeassembler/nestedtypeassembler_test.go
@@ -1,0 +1,237 @@
+package nestedtypeassembler
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-mock/param/form"
+	"github.com/stripe/stripe-mock/param/parser"
+)
+
+//
+// Tests
+//
+
+func TestAssembleParams_Basic(t *testing.T) {
+	assert.Equal(t, map[string]interface{}{
+		"foo": "bar",
+	}, mustAssembleParams(t, "foo=bar"))
+
+	assert.Equal(t, map[string]interface{}{
+		"foo": "7",
+	}, mustAssembleParams(t, "foo=7"))
+
+	assert.Equal(t, map[string]interface{}{
+		"a": "value1",
+		"b": "value2",
+		"c": "value3",
+	}, mustAssembleParams(t, "a=value1&b=value2&c=value3"))
+}
+
+func TestAssembleParams_Empty(t *testing.T) {
+	assert.Equal(t, map[string]interface{}{}, mustAssembleParams(t, ""))
+}
+
+func TestAssembleParams_Array(t *testing.T) {
+	assert.Equal(t, map[string]interface{}{
+		"arr": []interface{}{"value1"},
+	}, mustAssembleParams(t, "arr[]=value1"))
+
+	assert.Equal(t, map[string]interface{}{
+		"arr": []interface{}{"value1", "value2", "value3"},
+	}, mustAssembleParams(t, "arr[]=value1&arr[]=value2&arr[]=value3"))
+}
+
+// Here for completeness, but this kind of input is to a large degree nonsense
+// and hopefully not present anywhere in the Stripe API ...
+func TestAssembleParams_ArrayMulti(t *testing.T) {
+	assert.Equal(t, map[string]interface{}{
+		"arr": []interface{}{
+			[]interface{}{"value1"},
+		},
+	}, mustAssembleParams(t, "arr[][]=value1"))
+}
+
+func TestAssembleParams_Map(t *testing.T) {
+	assert.Equal(t, map[string]interface{}{
+		"map": map[string]interface{}{"key1": "value1"},
+	}, mustAssembleParams(t, "map[key1]=value1"))
+
+	assert.Equal(t, map[string]interface{}{
+		"map": map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+		},
+	}, mustAssembleParams(t, "map[key1]=value1&map[key2]=value2"))
+
+	assert.Equal(t, map[string]interface{}{
+		"map1": map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+		},
+		"map2": map[string]interface{}{
+			"key1": "value1",
+		},
+	}, mustAssembleParams(t, "map1[key1]=value1&map1[key2]=value2&map2[key1]=value1"))
+}
+
+func TestAssembleParams_MapNesting(t *testing.T) {
+	assert.Equal(t, map[string]interface{}{
+		"map": map[string]interface{}{
+			"key1": map[string]interface{}{
+				"key1": "value1_1",
+				"key2": "value1_2",
+			},
+			"key2": "value2",
+		},
+	}, mustAssembleParams(t, "map[key1][key1]=value1_1&map[key1][key2]=value1_2&map[key2]=value2"))
+
+	assert.Equal(t, map[string]interface{}{
+		"map": map[string]interface{}{
+			"key1": map[string]interface{}{
+				"key1": map[string]interface{}{
+					"key1": "value1",
+				},
+			},
+			"key2": "value2",
+		},
+	}, mustAssembleParams(t, "map[key1][key1][key1]=value1&map[key2]=value2"))
+}
+
+func TestAssembleParams_MapInArray(t *testing.T) {
+	assert.Equal(t, map[string]interface{}{
+		"obj": []interface{}{
+			map[string]interface{}{"key1": "value1"},
+		},
+	}, mustAssembleParams(t, "obj[][key1]=value1"))
+
+	assert.Equal(t, map[string]interface{}{
+		"obj": []interface{}{
+			map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+	}, mustAssembleParams(t, "obj[][key1]=value1&obj[][key2]=value2"))
+}
+
+func TestAssembleParams_MapInArrayMulti(t *testing.T) {
+	assert.Equal(t, map[string]interface{}{
+		"obj": []interface{}{
+			map[string]interface{}{
+				"key1": "value1_1",
+				"key2": "value1_2",
+			},
+			map[string]interface{}{
+				"key1": "value2_1",
+				"key2": "value2_2",
+			},
+		},
+	}, mustAssembleParams(t,
+		"obj[][key1]=value1_1&obj[][key2]=value1_2&"+
+			"obj[][key1]=value2_1&obj[][key2]=value2_2",
+	))
+}
+
+func TestAssembleParams_MapInArrayRepeating(t *testing.T) {
+	assert.Equal(t, map[string]interface{}{
+		"obj": []interface{}{
+			map[string]interface{}{
+				"key1": "value1",
+			},
+			map[string]interface{}{
+				"key1": "value2",
+			},
+		},
+	}, mustAssembleParams(t, "obj[][key1]=value1&obj[][key1]=value2"))
+}
+
+func TestAssembleParams_ArrayInMap(t *testing.T) {
+	assert.Equal(t, map[string]interface{}{
+		"obj": map[string]interface{}{
+			"key1": []interface{}{"value1"},
+		},
+	}, mustAssembleParams(t, "obj[key1][]=value1"))
+
+	assert.Equal(t, map[string]interface{}{
+		"obj": map[string]interface{}{
+			"key1": []interface{}{
+				"value1",
+				"value2",
+			},
+		},
+	}, mustAssembleParams(t, "obj[key1][]=value1&obj[key1][]=value2"))
+}
+
+func TestAssembleParams_ComplexNesting(t *testing.T) {
+	assert.Equal(t, map[string]interface{}{
+		"obj": []interface{}{
+			map[string]interface{}{
+				"key1": []interface{}{
+					"value1_1",
+					"value1_2",
+				},
+				"key2": map[string]interface{}{
+					"key": "value2",
+				},
+				"key3": "value3",
+			},
+		},
+	}, mustAssembleParams(t,
+		"obj[][key1][]=value1_1&obj[][key1][]=value1_2&"+
+			"obj[][key2][key]=value2&"+
+			"obj[][key3]=value3",
+	))
+}
+
+//
+// Tests for private functions
+//
+
+func TestParseKey(t *testing.T) {
+	assert.Equal(t, []keyPart{
+		&keyRaw{content: "name"},
+	}, parseKey("name"))
+
+	assert.Equal(t, []keyPart{
+		&keyRaw{content: "array"},
+		&keyArray{},
+	}, parseKey("array[]"))
+
+	assert.Equal(t, []keyPart{
+		&keyRaw{content: "map"},
+		&keyMap{content: "key"},
+	}, parseKey("map[key]"))
+
+	assert.Equal(t, []keyPart{
+		&keyRaw{content: "maparray"},
+		&keyArray{},
+		&keyMap{content: "key"},
+	}, parseKey("maparray[][key]"))
+
+	assert.Equal(t, []keyPart{
+		&keyRaw{content: "maparray"},
+		&keyArray{},
+		&keyMap{content: "key"},
+		&keyArray{},
+		&keyMap{content: "key"},
+		&keyMap{content: "key"},
+		&keyMap{content: "key"},
+	}, parseKey("maparray[][key][][key][key][key]"))
+}
+
+//
+// Private functions
+//
+
+func mustParse(t *testing.T, query string) form.FormValues {
+	values, err := parser.ParseFormString(query)
+	assert.NoError(t, err)
+	return values
+}
+
+func mustAssembleParams(t *testing.T, query string) map[string]interface{} {
+	params, err := AssembleParams(mustParse(t, query))
+	assert.NoError(t, err)
+	return params
+}

--- a/param/param.go
+++ b/param/param.go
@@ -1,0 +1,100 @@
+package param
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/stripe/stripe-mock/param/form"
+	"github.com/stripe/stripe-mock/param/nestedtypeassembler"
+	"github.com/stripe/stripe-mock/param/parser"
+)
+
+// ParseParams extracts parameters from a request that an application can
+// consume.
+//
+// Depending on the type of request, parameters may be extracted from either
+// the query string, a form-encoded body, or a multipart form-encoded body (the
+// latter being specific to only a very small number of endpoints).
+//
+// Regardless of origin, parameters are assumed to follow "Rack-style"
+// conventions for encoding complex types like arrays and maps, which is how
+// the Stripe API decodes data. These complex types are what makes the param
+// package's implementation non-trivial. We rely on the nestedtypeassembler
+// subpackage to do the heavy lifting for that.
+func ParseParams(r *http.Request) (map[string]interface{}, error) {
+	var values form.FormValues
+
+	contentType := r.Header.Get("Content-Type")
+
+	// Truncate content type parameters. For example, given:
+	//
+	//     application/json; charset=utf-8
+	//
+	// We want to chop off the `; charset=utf-8` at the end.
+	contentType = strings.Split(contentType, ";")[0]
+
+	if r.Method == "GET" {
+		formString := r.URL.RawQuery
+
+		var err error
+		values, err = parser.ParseFormString(formString)
+		if err != nil {
+			return nil, err
+		}
+	} else if contentType == MultipartMediaType {
+		err := r.ParseMultipartForm(MaxMemory)
+		if err != nil {
+			return nil, err
+		}
+
+		for key, keyValues := range r.MultipartForm.Value {
+			for _, keyValue := range keyValues {
+				values = append(values, form.FormPair{key, keyValue})
+			}
+		}
+
+		for key, keyValues := range r.MultipartForm.File {
+			for _, keyFileHeader := range keyValues {
+				file, err := keyFileHeader.Open()
+				if err != nil {
+					return nil, err
+				}
+
+				keyFileBytes, err := ioutil.ReadAll(file)
+				file.Close()
+				if err != nil {
+					return nil, err
+				}
+
+				values = append(values, form.FormPair{key, string(keyFileBytes)})
+			}
+		}
+	} else {
+		formBytes, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		r.Body.Close()
+
+		formString := string(formBytes)
+
+		values, err = parser.ParseFormString(formString)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return nestedtypeassembler.AssembleParams(values)
+}
+
+//
+// Private constants
+//
+
+// The maximum amount of memory allowed when ingesting a multipart form.
+//
+// Set to 1 MB.
+const MaxMemory = 1 * 1024 * 1024
+
+const MultipartMediaType = "multipart/form-data"

--- a/param/param_test.go
+++ b/param/param_test.go
@@ -1,0 +1,68 @@
+package param
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestParseParams_Get(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?foo=bar", nil)
+	params, err := ParseParams(req)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"foo": "bar",
+	}, params)
+}
+
+func TestParseParams_Form(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/",
+		bytes.NewBufferString("foo=bar"))
+	params, err := ParseParams(req)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"foo": "bar",
+	}, params)
+}
+
+func TestParseParams_MultipartForm(t *testing.T) {
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	assert.NoError(t, w.WriteField("foo", "bar"))
+	assert.NoError(t, w.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(b.Bytes()))
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	params, err := ParseParams(req)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"foo": "bar",
+	}, params)
+}
+
+// Differs from the above by sending a value as a file instead of as just a
+// basic multipart parameter. This more accurately represents what a file
+// upload would look like.
+func TestParseParams_MultipartFormFromFile(t *testing.T) {
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	fieldW, err := w.CreateFormFile("foo", "foo.txt")
+	assert.NoError(t, err)
+	_, err = fieldW.Write([]byte("bar"))
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(b.Bytes()))
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	params, err := ParseParams(req)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"foo": "bar",
+	}, params)
+}

--- a/param/parser/parser.go
+++ b/param/parser/parser.go
@@ -1,269 +1,23 @@
 package parser
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/stripe/stripe-mock/param/form"
 )
 
-// ParseFormString takes a form-encoded string and it turns it into a usable
-// set of parameters that an application can consume. These parameters use
-// "Rack-style" conventions for encoding complex types like arrays and maps,
-// which is how the Stripe API decodes data. These complex types are the more
-// difficult part of the problem and what makes this package fairly complicated
-// to implemented.
-func ParseFormString(s string) (map[string]interface{}, error) {
-	values, err := parseForm(s)
-	if err != nil {
-		return nil, err
-	}
-	return parseFormValues(values)
-}
-
 //
-// ---
+// Public functions
 //
 
-const (
-	keyTypeArray = iota
-	keyTypeMap
-	keyTypeRaw
-)
-
-// keyPart is an interface for a struct that represents a "part" of a parameter
-// key. For example, we might say that in `obj[]` the `[]` is an array part.
-type keyPart interface {
-	KeyType() int
-	Content() string
-}
-
-// keyType represents an array part of a parameter key, like the `[]` in
-// `obj[][foo]`.
-type keyArray struct {
-}
-
-func (k *keyArray) KeyType() int {
-	return keyTypeArray
-}
-
-func (k *keyArray) Content() string {
-	panic("keyArray doesn't support Content")
-}
-
-// keyMap represents a map part of a parameter key, like the `[foo]` in
-// `obj[][foo]`.
-type keyMap struct {
-	content string
-}
-
-func (k *keyMap) KeyType() int {
-	return keyTypeMap
-}
-
-func (k *keyMap) Content() string {
-	return k.content
-}
-
-// keyRaw represents the raw name of a parameter key, like the `obj` in
-// `obj[][foo]`.
-type keyRaw struct {
-	content string
-}
-
-func (k *keyRaw) KeyType() int {
-	return keyTypeRaw
-}
-
-func (k *keyRaw) Content() string {
-	return k.content
-}
-
-func parseKey(key string) []keyPart {
-	var keyParts []keyPart
-	var c rune
-	var i int
-	var mapContent []rune
-	var rawContent []rune
-
-	keyRunes := []rune(key)
-
-raw:
-	if i >= len(keyRunes) {
-		goto finished
-	}
-
-	c = keyRunes[i]
-	i++
-
-	if c == '[' {
-		if len(rawContent) > 0 {
-			keyParts = append(keyParts, &keyRaw{content: string(rawContent)})
-			rawContent = nil
-		}
-
-		goto inMapOrArray
-	}
-
-	rawContent = append(rawContent, c)
-	goto raw
-
-inMapOrArray:
-	if i >= len(keyRunes) {
-		goto finished
-	}
-
-	c = keyRunes[i]
-	i++
-
-	if c == ']' {
-		keyParts = append(keyParts, &keyArray{})
-		goto raw
-	}
-
-	mapContent = append(mapContent, c)
-
-	// Fall through to inMap
-
-inMap:
-	if i >= len(keyRunes) {
-		goto finished
-	}
-
-	c = keyRunes[i]
-	i++
-
-	if c == ']' {
-		keyParts = append(keyParts, &keyMap{content: string(mapContent)})
-		mapContent = nil
-		goto raw
-	}
-
-	mapContent = append(mapContent, c)
-	goto inMap
-
-finished:
-	if len(keyParts) == 0 && len(rawContent) > 0 {
-		keyParts = append(keyParts, &keyRaw{content: string(rawContent)})
-		rawContent = nil
-	}
-
-	return keyParts
-}
-
-func buildParamStructure(key string, parts []keyPart, value string) (map[string]interface{}, error) {
-	params := make(map[string]interface{})
-
-	if len(parts) == 0 {
-		params[key] = value
-		return params, nil
-	}
-
-	part := parts[0]
-
-	switch part.KeyType() {
-	case keyTypeArray:
-		subParams, err := buildParamStructure("dummy", parts[1:], value)
-		if err != nil {
-			return nil, err
-		}
-		params[key] = []interface{}{subParams["dummy"]}
-
-	case keyTypeMap:
-		subParams, err := buildParamStructure(part.Content(), parts[1:], value)
-		if err != nil {
-			return nil, err
-		}
-		params[key] = subParams
-
-	default:
-		return nil, fmt.Errorf("Invalid key. Raw content can't be mixed in after arrays and maps.")
-	}
-
-	return params, nil
-}
-
-func maybeCollapseArrays(arr1, arr2 []interface{}) bool {
-	//fmt.Printf("maybe collapse arrays %+v %+v\n", arr1, arr2)
-
-	if len(arr2) != 1 {
-		panic("Expected array with length exactly 1")
-	}
-
-	// arr1's merge candidate is its last element only
-	arr1Map, ok := arr1[len(arr1)-1].(map[string]interface{})
-	if !ok {
-		return false
-	}
-
-	arr2Map, ok := arr2[0].(map[string]interface{})
-	if !ok {
-		return false
-	}
-
-	// If any of the keys in arr2's map are already in arr1's map, then don't
-	// merge we consider this a new map.
-	for key := range arr2Map {
-		val, ok := arr1Map[key]
-		if ok {
-			_, okArr := val.([]interface{})
-			_, okMap := val.(map[string]interface{})
-			if !okArr && !okMap {
-				return false
-			}
-		}
-	}
-
-	mergeMapsRecursive(arr1Map, arr2Map)
-	return true
-}
-
-func mergeMapsRecursive(map1, map2 map[string]interface{}) {
-	for key, val2 := range map2 {
-		val1, ok := map1[key]
-		if ok {
-			val1Map, ok := val1.(map[string]interface{})
-			if ok {
-				val2Map, ok := val2.(map[string]interface{})
-				if ok {
-					mergeMapsRecursive(val1Map, val2Map)
-					continue
-				}
-			}
-
-			val1Arr, ok := val1.([]interface{})
-			if ok {
-				val2Arr, ok := val2.([]interface{})
-				if ok {
-					ok := maybeCollapseArrays(val1Arr, val2Arr)
-					if !ok {
-						map1[key] = append(val1Arr, val2Arr...)
-					}
-					continue
-				}
-			}
-		}
-
-		// If not an array or map, or we couldn't reconcile types between the
-		// two maps, simply set the key in map1 to the value from map2.
-		map1[key] = val2
-	}
-}
-
-// formPair is a key/value pair as extracted from a form-encoded string. For
-// example, "a=b" is the pair [a, b].
-type formPair [2]string
-
-// formValues is a full slice of all the key/value pairs from a form-encoded
-// string.
-type formValues []formPair
-
-// parseForm parses a form-encoded body or query into a set of key/value pairs.
-// It differs from url.ParseQuery in that because it produces a slice instead
-// of a map, order can be preserved. This is key to properly decoding
+// ParseFormString parses a form-encoded body or query into a set of key/value
+// pairs. It differs from url.ParseQuery in that because it produces a slice
+// instead of a map, order can be preserved. This is key to properly decoding
 // "Rack-style" form encoding.
 //
 // Implementation modified from: https://github.com/deoxxa/urlqp
-func parseForm(s string) (formValues, error) {
+func ParseFormString(s string) (form.FormValues, error) {
 	s = strings.TrimPrefix(s, "?")
 
 	if s == "" {
@@ -271,7 +25,7 @@ func parseForm(s string) (formValues, error) {
 	}
 
 	rawValues := strings.Split(s, "&")
-	r := make(formValues, len(rawValues))
+	r := make(form.FormValues, len(rawValues))
 
 	for i, rawValue := range rawValues {
 		// Split this raw form value into two parts, at the first `=`
@@ -294,39 +48,8 @@ func parseForm(s string) (formValues, error) {
 			}
 		}
 
-		r[i] = formPair{formKey, v}
+		r[i] = form.FormPair{formKey, v}
 	}
 
 	return r, nil
-}
-
-func parseFormValues(form formValues) (map[string]interface{}, error) {
-	params := make(map[string]interface{})
-
-	for _, pair := range form {
-		key := pair[0]
-		value := pair[1]
-
-		keyParts := parseKey(key)
-
-		if len(keyParts) == 0 {
-			continue
-		}
-
-		rawkeyPart := keyParts[0]
-		if rawkeyPart.KeyType() != keyTypeRaw {
-			return nil, fmt.Errorf(`Invalid key "%v". Keys must start with a name.`, key)
-		}
-
-		pairParams, err := buildParamStructure(rawkeyPart.Content(), keyParts[1:], value)
-		if err != nil {
-			return nil, err
-		}
-
-		//fmt.Printf("new params = %+v\n", pairParams)
-		mergeMapsRecursive(params, pairParams)
-		//fmt.Printf("merge result = %+v\n\n", params)
-	}
-
-	return params, nil
 }

--- a/param/parser/parser_test.go
+++ b/param/parser/parser_test.go
@@ -4,297 +4,74 @@ import (
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-mock/param/form"
 )
+
+//
+// Tests
+//
 
 func TestParseForm(t *testing.T) {
 	var err error
-	var v formValues
+	var v form.FormValues
 
-	v, err = parseForm(``)
+	v, err = ParseFormString(``)
 	assert.NoError(t, err)
 	assert.Nil(t, v)
 
-	v, err = parseForm(`a=b&c=d&e=f`)
+	v, err = ParseFormString(`a=b&c=d&e=f`)
 	assert.NoError(t, err)
-	assert.Equal(t, formValues{
-		formPair{"a", "b"},
-		formPair{"c", "d"},
-		formPair{"e", "f"},
+	assert.Equal(t, form.FormValues{
+		form.FormPair{"a", "b"},
+		form.FormPair{"c", "d"},
+		form.FormPair{"e", "f"},
 	}, v)
 
-	v, err = parseForm(`a=b&a=c`)
+	v, err = ParseFormString(`a=b&a=c`)
 	assert.NoError(t, err)
-	assert.Equal(t, formValues{
-		formPair{"a", "b"},
-		formPair{"a", "c"},
+	assert.Equal(t, form.FormValues{
+		form.FormPair{"a", "b"},
+		form.FormPair{"a", "c"},
 	}, v)
 
-	v, err = parseForm(`a=b&a=b`)
+	v, err = ParseFormString(`a=b&a=b`)
 	assert.NoError(t, err)
-	assert.Equal(t, formValues{
-		formPair{"a", "b"},
-		formPair{"a", "b"},
+	assert.Equal(t, form.FormValues{
+		form.FormPair{"a", "b"},
+		form.FormPair{"a", "b"},
 	}, v)
 
-	v, err = parseForm(`?a=b&a=b`)
+	v, err = ParseFormString(`?a=b&a=b`)
 	assert.NoError(t, err)
-	assert.Equal(t, formValues{
-		formPair{"a", "b"},
-		formPair{"a", "b"},
+	assert.Equal(t, form.FormValues{
+		form.FormPair{"a", "b"},
+		form.FormPair{"a", "b"},
 	}, v)
 
-	v, err = parseForm(`?x=%20&%20=x`)
+	v, err = ParseFormString(`?x=%20&%20=x`)
 	assert.NoError(t, err)
-	assert.Equal(t, formValues{
-		formPair{"x", " "},
-		formPair{" ", "x"},
+	assert.Equal(t, form.FormValues{
+		form.FormPair{"x", " "},
+		form.FormPair{" ", "x"},
 	}, v)
 
-	v, err = parseForm(`?x=+&+=x`)
+	v, err = ParseFormString(`?x=+&+=x`)
 	assert.NoError(t, err)
-	assert.Equal(t, formValues{
-		formPair{"x", " "},
-		formPair{" ", "x"},
+	assert.Equal(t, form.FormValues{
+		form.FormPair{"x", " "},
+		form.FormPair{" ", "x"},
 	}, v)
 
-	v, err = parseForm(`?x=%2c&%2c=x`)
+	v, err = ParseFormString(`?x=%2c&%2c=x`)
 	assert.NoError(t, err)
-	assert.Equal(t, formValues{
-		formPair{"x", ","},
-		formPair{",", "x"},
+	assert.Equal(t, form.FormValues{
+		form.FormPair{"x", ","},
+		form.FormPair{",", "x"},
 	}, v)
 
-	_, err = parseForm(`%`)
+	_, err = ParseFormString(`%`)
 	assert.Error(t, err)
 
-	_, err = parseForm(`a=%`)
+	_, err = ParseFormString(`a=%`)
 	assert.Error(t, err)
-}
-
-func TestParseKey(t *testing.T) {
-	assert.Equal(t, []keyPart{
-		&keyRaw{content: "name"},
-	}, parseKey("name"))
-
-	assert.Equal(t, []keyPart{
-		&keyRaw{content: "array"},
-		&keyArray{},
-	}, parseKey("array[]"))
-
-	assert.Equal(t, []keyPart{
-		&keyRaw{content: "map"},
-		&keyMap{content: "key"},
-	}, parseKey("map[key]"))
-
-	assert.Equal(t, []keyPart{
-		&keyRaw{content: "maparray"},
-		&keyArray{},
-		&keyMap{content: "key"},
-	}, parseKey("maparray[][key]"))
-
-	assert.Equal(t, []keyPart{
-		&keyRaw{content: "maparray"},
-		&keyArray{},
-		&keyMap{content: "key"},
-		&keyArray{},
-		&keyMap{content: "key"},
-		&keyMap{content: "key"},
-		&keyMap{content: "key"},
-	}, parseKey("maparray[][key][][key][key][key]"))
-}
-
-func TestParseFormString(t *testing.T) {
-	data, err := ParseFormString("foo=bar")
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
-		"foo": "bar",
-	}, data)
-}
-
-func TestParseFormValues_Basic(t *testing.T) {
-	assert.Equal(t, map[string]interface{}{
-		"foo": "bar",
-	}, mustParseFormValues(t, "foo=bar"))
-
-	assert.Equal(t, map[string]interface{}{
-		"foo": "7",
-	}, mustParseFormValues(t, "foo=7"))
-
-	assert.Equal(t, map[string]interface{}{
-		"a": "value1",
-		"b": "value2",
-		"c": "value3",
-	}, mustParseFormValues(t, "a=value1&b=value2&c=value3"))
-}
-
-func TestParseFormValues_Empty(t *testing.T) {
-	assert.Equal(t, map[string]interface{}{}, mustParseFormValues(t, ""))
-}
-
-func TestParseFormValues_Array(t *testing.T) {
-	assert.Equal(t, map[string]interface{}{
-		"arr": []interface{}{"value1"},
-	}, mustParseFormValues(t, "arr[]=value1"))
-
-	assert.Equal(t, map[string]interface{}{
-		"arr": []interface{}{"value1", "value2", "value3"},
-	}, mustParseFormValues(t, "arr[]=value1&arr[]=value2&arr[]=value3"))
-}
-
-// Here for completeness, but this kind of input is to a large degree nonsense
-// and hopefully not present anywhere in the Stripe API ...
-func TestParseFormValues_ArrayMulti(t *testing.T) {
-	assert.Equal(t, map[string]interface{}{
-		"arr": []interface{}{
-			[]interface{}{"value1"},
-		},
-	}, mustParseFormValues(t, "arr[][]=value1"))
-}
-
-func TestParseFormValues_Map(t *testing.T) {
-	assert.Equal(t, map[string]interface{}{
-		"map": map[string]interface{}{"key1": "value1"},
-	}, mustParseFormValues(t, "map[key1]=value1"))
-
-	assert.Equal(t, map[string]interface{}{
-		"map": map[string]interface{}{
-			"key1": "value1",
-			"key2": "value2",
-		},
-	}, mustParseFormValues(t, "map[key1]=value1&map[key2]=value2"))
-
-	assert.Equal(t, map[string]interface{}{
-		"map1": map[string]interface{}{
-			"key1": "value1",
-			"key2": "value2",
-		},
-		"map2": map[string]interface{}{
-			"key1": "value1",
-		},
-	}, mustParseFormValues(t, "map1[key1]=value1&map1[key2]=value2&map2[key1]=value1"))
-}
-
-func TestParseFormValues_MapNesting(t *testing.T) {
-	assert.Equal(t, map[string]interface{}{
-		"map": map[string]interface{}{
-			"key1": map[string]interface{}{
-				"key1": "value1_1",
-				"key2": "value1_2",
-			},
-			"key2": "value2",
-		},
-	}, mustParseFormValues(t, "map[key1][key1]=value1_1&map[key1][key2]=value1_2&map[key2]=value2"))
-
-	assert.Equal(t, map[string]interface{}{
-		"map": map[string]interface{}{
-			"key1": map[string]interface{}{
-				"key1": map[string]interface{}{
-					"key1": "value1",
-				},
-			},
-			"key2": "value2",
-		},
-	}, mustParseFormValues(t, "map[key1][key1][key1]=value1&map[key2]=value2"))
-}
-
-func TestParseFormValues_MapInArray(t *testing.T) {
-	assert.Equal(t, map[string]interface{}{
-		"obj": []interface{}{
-			map[string]interface{}{"key1": "value1"},
-		},
-	}, mustParseFormValues(t, "obj[][key1]=value1"))
-
-	assert.Equal(t, map[string]interface{}{
-		"obj": []interface{}{
-			map[string]interface{}{
-				"key1": "value1",
-				"key2": "value2",
-			},
-		},
-	}, mustParseFormValues(t, "obj[][key1]=value1&obj[][key2]=value2"))
-}
-
-func TestParseFormValues_MapInArrayMulti(t *testing.T) {
-	assert.Equal(t, map[string]interface{}{
-		"obj": []interface{}{
-			map[string]interface{}{
-				"key1": "value1_1",
-				"key2": "value1_2",
-			},
-			map[string]interface{}{
-				"key1": "value2_1",
-				"key2": "value2_2",
-			},
-		},
-	}, mustParseFormValues(t,
-		"obj[][key1]=value1_1&obj[][key2]=value1_2&"+
-			"obj[][key1]=value2_1&obj[][key2]=value2_2",
-	))
-}
-
-func TestParseFormValues_MapInArrayRepeating(t *testing.T) {
-	assert.Equal(t, map[string]interface{}{
-		"obj": []interface{}{
-			map[string]interface{}{
-				"key1": "value1",
-			},
-			map[string]interface{}{
-				"key1": "value2",
-			},
-		},
-	}, mustParseFormValues(t, "obj[][key1]=value1&obj[][key1]=value2"))
-}
-
-func TestParseFormValues_ArrayInMap(t *testing.T) {
-	assert.Equal(t, map[string]interface{}{
-		"obj": map[string]interface{}{
-			"key1": []interface{}{"value1"},
-		},
-	}, mustParseFormValues(t, "obj[key1][]=value1"))
-
-	assert.Equal(t, map[string]interface{}{
-		"obj": map[string]interface{}{
-			"key1": []interface{}{
-				"value1",
-				"value2",
-			},
-		},
-	}, mustParseFormValues(t, "obj[key1][]=value1&obj[key1][]=value2"))
-}
-
-func TestParseFormValues_ComplexNesting(t *testing.T) {
-	assert.Equal(t, map[string]interface{}{
-		"obj": []interface{}{
-			map[string]interface{}{
-				"key1": []interface{}{
-					"value1_1",
-					"value1_2",
-				},
-				"key2": map[string]interface{}{
-					"key": "value2",
-				},
-				"key3": "value3",
-			},
-		},
-	}, mustParseFormValues(t,
-		"obj[][key1][]=value1_1&obj[][key1][]=value1_2&"+
-			"obj[][key2][key]=value2&"+
-			"obj[][key3]=value3",
-	))
-}
-
-//
-// ---
-//
-
-func mustParse(t *testing.T, query string) formValues {
-	values, err := parseForm(query)
-	assert.NoError(t, err)
-	return values
-}
-
-func mustParseFormValues(t *testing.T, query string) map[string]interface{} {
-	params, err := parseFormValues(mustParse(t, query))
-	assert.NoError(t, err)
-	return params
 }


### PR DESCRIPTION
This makes the changes necessary to be able to successfully validate
payloads sent as `multipart/form-data` along with the standard
`application/x-www-form-urlencoded`.

To accomplish this, I ended up splitting the parameter parser into two
separate components:

1. A new "parser" that just splits an incoming string into form
   key/value tuples. This is used to parse query strings and body form
   data. We prefer it over Go's built-in parser because it returns
   an ordered slice instead of an unordered map, which is critical for
   correctly parsing incoming arrays and maps.
2. An "assembler" that takes the parser's output and assembles
   higher-level data structures from it, including arrays and maps by
   using the "Rack-style" conventions in use by the Stripe API.

To parse `multipart/form-data`, we rely on Go's built-in multipart
parser, and then hands off its results to our new assembler. You can see
all of this at work in `param.ParseParams`.

In addition, it tweaks behavior so that if a client sends either an
empty `Content-Type` header where one was expected (i.e., usually
non-`GET`) or a `Content-Type` that doesn't match the expected media
type of the responding endpoint, `stripe-mock` will respond with an
error.

This last part is intended to be an extra safety feature to help ensure
that client implementations are correct. In particular, it should be
helpful in making sure that file API endpoints receive
`multipart/form-data` instead of the standard
`application/x-www-form-urlencoded`.

So the one big caveat is that file uploads in `stripe-ruby` and other
libraries will still not quite succeed against these changes. To get
them fully working we need to change the type of the "file create"
endpoint's `file` parameter from an object to a string. I have another
pull going into the backend to do this.

Fixes #69.

r? @tmaxwell-stripe  Hey sorry, this is another relatively large change. Mind taking a
quick pass over it? I think that things could always be better, but this
continues to take us in a more correct direction, further modularizes, and adds
more testing than we had before. Thanks!

cc @stripe/api-libraries