### PR TITLE
Replace data in response with data from request

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/stripe/stripe-mock/generator/datareplacer"
 	"github.com/stripe/stripe-mock/spec"
 )
 
@@ -32,6 +33,14 @@ type GenerateParams struct {
 	// The value of this field is considered in a post-processing step for the
 	// generator. It's not used in the generator at all.
 	PathParams *PathParamsMap
+
+	// RequestData is a collection of decoded data that was included as part of
+	// the request's payload.
+	//
+	// It's used to find opportunities to reflect information included with a
+	// request into the response to make responses look more accurate than
+	// they'd otherwise be if they'd been generated from fixtures alone..
+	RequestData map[string]interface{}
 
 	// RequestPath is the path of the URL being requested which we're
 	// generating data for. It's used to populate the url property of any
@@ -107,6 +116,10 @@ func (g *DataGenerator) Generate(params *GenerateParams) (interface{}, error) {
 		// IDs that we replaced. This is a separate step because IDs could have
 		// been found and replace at any point in the generation process.
 		distributeReplacedIDs(pathParams, data)
+	}
+
+	if mapData, ok := data.(map[string]interface{}); ok {
+		mapData = datareplacer.ReplaceData(params.RequestData, mapData)
 	}
 
 	return data, nil

--- a/generator/datareplacer/datareplacer.go
+++ b/generator/datareplacer/datareplacer.go
@@ -1,0 +1,50 @@
+package datareplacer
+
+import (
+	"reflect"
+)
+
+func ReplaceData(requestData map[string]interface{}, responseData map[string]interface{}) map[string]interface{} {
+	for k, requestValue := range requestData {
+		responseValue, ok := responseData[k]
+
+		// Recursively call in to replace data, but only if the key is
+		// in both maps.
+		//
+		// A fairly obvious improvement here is if a key is in the
+		// request but not present in the response, then check the
+		// canonical schema to see if it's there. It might be an
+		// optional field that doesn't appear in the fixture, and if it
+		// was given to us with the request, we probably want to
+		// include it.
+		if ok {
+			requestKeyMap, requestKeyOK := requestValue.(map[string]interface{})
+			responseKeyMap, responseKeyOK := responseValue.(map[string]interface{})
+
+			if requestKeyOK && responseKeyOK {
+				responseData[k] = ReplaceData(requestKeyMap, responseKeyMap)
+			} else {
+				// In the non-map case, just set the respons key's value to
+				// what was in the request, but only if both values are the
+				// same type (this is to prevent problems where a field is set
+				// as an ID, but the response field is the hydrated object of
+				// that).
+				//
+				// While this will largely be "good enough", there's some
+				// obvious cases that aren't going to be handled correctly like
+				// index-based array updates (e.g.,
+				// `additional_owners[1][name]=...`). I'll have to iron out
+				// that rough edges later on.
+				if isSameType(requestValue, responseValue) {
+					responseData[k] = requestValue
+				}
+			}
+		}
+	}
+
+	return responseData
+}
+
+func isSameType(v1, v2 interface{}) bool {
+	return reflect.ValueOf(v1).Type() == reflect.ValueOf(v2).Type()
+}

--- a/generator/datareplacer/datareplacer_test.go
+++ b/generator/datareplacer/datareplacer_test.go
@@ -1,0 +1,94 @@
+package datareplacer
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+//
+// Tests
+//
+
+func TestReplaceData_Basic(t *testing.T) {
+	responseData := map[string]interface{}{
+		"foo": "response-value",
+	}
+
+	ReplaceData(map[string]interface{}{
+		"foo": "request-value",
+	}, responseData)
+
+	assert.Equal(t, map[string]interface{}{
+		"foo": "request-value",
+	}, responseData)
+}
+
+// Arrays are currently just replaced wholesale.
+func TestReplaceData_Array(t *testing.T) {
+	responseData := map[string]interface{}{
+		"arr": []string{
+			"response-value",
+		},
+	}
+
+	ReplaceData(map[string]interface{}{
+		"arr": []string{
+			"request-value",
+		},
+	}, responseData)
+
+	assert.Equal(t, map[string]interface{}{
+		"arr": []string{
+			"request-value",
+		},
+	}, responseData)
+}
+
+func TestReplaceData_Recursive(t *testing.T) {
+	responseData := map[string]interface{}{
+		"map": map[string]interface{}{
+			"nested": "response-value",
+		},
+	}
+
+	ReplaceData(map[string]interface{}{
+		"map": map[string]interface{}{
+			"nested": "request-value",
+		},
+	}, responseData)
+
+	assert.Equal(t, map[string]interface{}{
+		"map": map[string]interface{}{
+			"nested": "request-value",
+		},
+	}, responseData)
+}
+
+func TestReplaceData_DontReplaceOnDifferentFields(t *testing.T) {
+	responseData := map[string]interface{}{
+		"other": "other-value",
+	}
+
+	ReplaceData(map[string]interface{}{
+		"foo": "request-value",
+	}, responseData)
+
+	assert.Equal(t, map[string]interface{}{
+		"other": "other-value",
+	}, responseData)
+}
+
+func TestReplaceData_DontReplaceOnDifferentTypes(t *testing.T) {
+	responseData := map[string]interface{}{
+		"foo": "response-value",
+	}
+
+	ReplaceData(map[string]interface{}{
+		"foo": 7,
+	}, responseData)
+
+	assert.Equal(t, map[string]interface{}{
+		"foo": "response-value",
+	}, responseData)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -68,6 +68,7 @@ func initTestSpec() {
 			Content: map[string]spec.MediaType{
 				"application/x-www-form-urlencoded": {
 					Schema: &spec.Schema{
+						AdditionalProperties: false,
 						Properties: map[string]*spec.Schema{
 							"amount": {
 								Type: "integer",

--- a/server.go
+++ b/server.go
@@ -201,6 +201,7 @@ func (s *StubServer) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	responseData, err := generator.Generate(&GenerateParams{
 		Expansions:  expansions,
 		PathParams:  pathParams,
+		RequestData: requestData,
 		RequestPath: r.URL.Path,
 		Schema:      responseContent.Schema,
 	})
@@ -602,6 +603,7 @@ func validateAndCoerceRequest(
 		return nil, createStripeError(typeInvalidRequestError, message)
 	}
 
+	fmt.Printf("Request data = %+v\n", requestData)
 	err = route.requestBodyValidator.Validate(requestData)
 	if err != nil {
 		message := fmt.Sprintf("Request validation error: %v", err)

--- a/spec/validate.go
+++ b/spec/validate.go
@@ -56,6 +56,12 @@ func GetComponentsForValidation(components *Components) *ComponentsForValidation
 // type, and it must be updated when new options are supported.
 func getJSONSchemaForOpenAPI3Schema(oai *Schema) map[string]interface{} {
 	jss := make(map[string]interface{})
+	if oai.AdditionalProperties != nil {
+		// We currently don't decode `AdditionalProperties` into a custom
+		// struct, so it's a pretty direct JSON representation. Just set it
+		// directly.
+		jss["additionalProperties"] = oai.AdditionalProperties
+	}
 	if len(oai.AnyOf) != 0 {
 		var jssAnyOf = make([]interface{}, len(oai.AnyOf))
 		for index, oaiSubschema := range oai.AnyOf {
@@ -75,6 +81,9 @@ func getJSONSchemaForOpenAPI3Schema(oai *Schema) map[string]interface{} {
 	}
 	if oai.Items != nil {
 		jss["items"] = getJSONSchemaForOpenAPI3Schema(oai.Items)
+	}
+	if oai.Pattern != "" {
+		jss["pattern"] = oai.Pattern
 	}
 	if len(oai.Properties) != 0 {
 		var jssProperties = make(map[string]interface{})

--- a/vendor/github.com/lestrrat/go-jsval/object.go
+++ b/vendor/github.com/lestrrat/go-jsval/object.go
@@ -2,8 +2,10 @@ package jsval
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 
 	"github.com/lestrrat/go-pdebug"
 )
@@ -463,7 +465,12 @@ func (o *ObjectConstraint) Validate(v interface{}) (err error) {
 	if len(premain) > 0 {
 		c := o.additionalProperties
 		if c == nil {
-			return errors.New("additional properties are not allowed")
+			var additionalNames []string
+			for pname := range premain {
+				additionalNames = append(additionalNames, pname)
+			}
+			return errors.New(fmt.Sprintf("additional properties are not allowed: %s",
+				strings.Join(additionalNames, ", ")))
 		}
 
 		for pname := range premain {


### PR DESCRIPTION
Here we try to to some additional enrichment on response data by
replacing what we found in fixtures with data that came in from the
request.

The algorithm is quite simple: we walk the decoded request object and
the generated response object, replace any scalars that we see where the
key name is the same, and recurse in when we see two keys with the same
names that are both maps.

In addition, I realized that we are no longer vetting that incorrect
keys are not being passed to stripe-mock, which appears to be a
regression from a change passed some time ago. This patch also adds back
a check on `additionalProperties: false`.

cc @tmaxwell-stripe Any thoughts on this?
cc @stripe/api-libraries 