### PR TITLE
Reflect `Idempotency-Key` header back in response

### DIFF
--- a/server.go
+++ b/server.go
@@ -135,6 +135,13 @@ func (s *StubServer) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// We don't do anything with the idempotency key for now, but reflect it
+	// back into response headers like the Stripe API does.
+	idempotencyKey := r.Header.Get("Idempotency-Key")
+	if idempotencyKey != "" {
+		w.Header().Set("Idempotency-Key", idempotencyKey)
+	}
+
 	// Every response needs a Request-Id header except the invalid authorization
 	w.Header().Set("Request-Id", "req_123")
 

--- a/server_test.go
+++ b/server_test.go
@@ -172,6 +172,15 @@ func TestStubServer_ErrorsOnMismatchedContentType(t *testing.T) {
 		errorInfo["message"])
 }
 
+func TestStubServer_ReflectsIdempotencyKey(t *testing.T) {
+	headers := getDefaultHeaders()
+	headers["Idempotency-Key"] = "my-key"
+
+	resp, _ := sendRequest(t, "POST", "/v1/charges",
+		"amount=123", headers)
+	assert.Equal(t, "my-key", resp.Header.Get("Idempotency-Key"))
+}
+
 func TestStubServer_RoutesRequest(t *testing.T) {
 	server := getStubServer(t)
 


### PR DESCRIPTION
Behave like the real Stripe API by reflecting an idempotency key that
was sent into stripe-mock back in the response body.