### PR TITLE
Listen for HTTP and HTTPS simultaneously in .plist

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -29,8 +29,10 @@ brew:
         <key>ProgramArguments</key>
         <array>
           <string>#{opt_bin}/stripe-mock</string>
-          <string>-port</string>
+          <string>-http-port</string>
           <string>12111</string>
+          <string>-https-port</string>
+          <string>12112</string>
         </array>
         <key>RunAtLoad</key>
         <true/>


### PR DESCRIPTION
See stripe/stripe-mock#84 for full context, but here we change
Goreleaser's .plist so that when the Homebrew tap is used, we listen on
both port 12111 and port 12112 for HTTPS.

I originally opened this at stripe/homebrew-stripe-mock#4, but forgot
that that wasn't the right place to change this setting. It needs to be
done in `goreleaser.yml` instead.