### PR TITLE
Whitelist RPC-style actions `/approve` and `/decline`

### DIFF
--- a/server.go
+++ b/server.go
@@ -399,9 +399,11 @@ var hasPrimaryIDSuffixes = [...]string{
 
 	// These are resource "actions". They don't take the standard form, but we
 	// can expect an object's primary ID to live right before them in a path.
+	"/approve",
 	"/capture",
 	"/cancel",
 	"/close",
+	"/decline",
 	"/pay",
 	"/refund",
 	"/reject",


### PR DESCRIPTION
stripe-mock currently needs a whitelist of RPC-style names so that it
can differentiate between an RPC endpoint and a subcollection when
deciding whether to include the primary ID from a URL.

Here we add two new ones for `/approve` and `/decline`.

r? @zanker-stripe
cc @remi-stripe