### PR TITLE
Decide between returning a deleted versus non-deleted from HTTP method

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -120,7 +120,12 @@ func initTestSpec() {
 					"customer": "cus_123",
 					"id":       "ch_123",
 				},
-				spec.ResourceID("customer"): map[string]interface{}{"id": "cus_123"},
+				spec.ResourceID("customer"): map[string]interface{}{
+					"id": "cus_123",
+				},
+				spec.ResourceID("deleted_customer"): map[string]interface{}{
+					"deleted": true,
+				},
 			},
 		}
 
@@ -151,6 +156,13 @@ func initTestSpec() {
 				"customer": {
 					Type:        "object",
 					XResourceID: "customer",
+				},
+				"deleted_customer": {
+					Properties: map[string]*spec.Schema{
+						"deleted": {Type: "boolean"},
+					},
+					Type:        "object",
+					XResourceID: "deleted_customer",
 				},
 			},
 		},

--- a/server.go
+++ b/server.go
@@ -206,11 +206,12 @@ func (s *StubServer) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 	generator := DataGenerator{s.spec.Components.Schemas, s.fixtures}
 	responseData, err := generator.Generate(&GenerateParams{
-		Expansions:  expansions,
-		PathParams:  pathParams,
-		RequestData: requestData,
-		RequestPath: r.URL.Path,
-		Schema:      responseContent.Schema,
+		Expansions:    expansions,
+		PathParams:    pathParams,
+		RequestData:   requestData,
+		RequestMethod: r.Method,
+		RequestPath:   r.URL.Path,
+		Schema:        responseContent.Schema,
 	})
 	if err != nil {
 		fmt.Printf("Couldn't generate response: %v\n", err)


### PR DESCRIPTION
Implements a simple heuristic so that stripe-mock will pick an `anyOf`
branch based off whether the incoming HTTP request method is a `DELETE`
or or not. If it is `DELETE`, we try to pick the deleted form of a
resource, and vice versa.

We're doing this because we'd occasionally run into a place where
stripe-mock was picking a branch based off its naive "pick the first
branch" logic when it was quite obvious that another branch would
overwhelmingly have been preferred. For example, returning a deleted
customer from `GET /v1/customers/:id` because the deleted customer
appeared first in the `anyOf` list.

The heuristic isn't perfect, but it will usually do the right thing.

r? @ob-stripe
cc @stripe/api-libraries