### PR TITLE
Don't replace data on non-`POST` endpoints

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -129,8 +129,12 @@ func (g *DataGenerator) Generate(params *GenerateParams) (interface{}, error) {
 		distributeReplacedIDs(pathParams, data)
 	}
 
-	if mapData, ok := data.(map[string]interface{}); ok {
-		mapData = datareplacer.ReplaceData(params.RequestData, mapData)
+	// In `POST` requests we reflect input parameters into responses to try and
+	// simulate a more realistic create or update operation.
+	if params.RequestMethod == http.MethodPost {
+		if mapData, ok := data.(map[string]interface{}); ok {
+			mapData = datareplacer.ReplaceData(params.RequestData, mapData)
+		}
 	}
 
 	return data, nil

--- a/generator_test.go
+++ b/generator_test.go
@@ -264,6 +264,38 @@ func TestGenerateResponseData(t *testing.T) {
 			data.(map[string]interface{})["customer"])
 	}
 
+	// data replacement on `POST`
+	{
+		generator := DataGenerator{testSpec.Components.Schemas, &testFixtures}
+		data, err := generator.Generate(&GenerateParams{
+			RequestData: map[string]interface{}{
+				"customer": "cus_9999",
+			},
+			RequestMethod: http.MethodPost,
+			Schema:        &spec.Schema{Ref: "#/components/schemas/charge"},
+		})
+		assert.Nil(t, err)
+		assert.Equal(t,
+			"cus_9999",
+			data.(map[string]interface{})["customer"])
+	}
+
+	// *no* data replacement on non-`POST`
+	{
+		generator := DataGenerator{testSpec.Components.Schemas, &testFixtures}
+		data, err := generator.Generate(&GenerateParams{
+			RequestData: map[string]interface{}{
+				"customer": "cus_9999",
+			},
+			RequestMethod: http.MethodGet,
+			Schema:        &spec.Schema{Ref: "#/components/schemas/charge"},
+		})
+		assert.Nil(t, err)
+		assert.NotEqual(t,
+			"cus_9999",
+			data.(map[string]interface{})["customer"])
+	}
+
 	// synthetic schema
 	{
 		generator := DataGenerator{testSpec.Components.Schemas, &testFixtures}


### PR DESCRIPTION
stripe-mock has a feature where it reflects data from input parameters
back into the response so that when creating an updating objects, it
produces responses that look more realistic with some of the actual
input values that were sent in.

Unfortunately, we found that this was working a little _too_ well and
being applied to other operations like listing as well. So for example,
if we request a list with a filter of `object=source`, we'd see a
response where the response list object's `object` field was set to
`source` instead of `list` like it should be.

Here we make sure that data replacement only occurs on `POST`
operations and add some tests to verify this behavior.

r? @remi-stripe
cc @dpetrovics-stripe 