### PR TITLE
Fix port number specification for Docker command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ HTTP/2.
 # build
 docker build . -t stripe-mock
 # run
-docker run -p 12111:12112 stripe-mock
+docker run -p 12111-12112:12111-12112 stripe-mock
 ```
 
 The default Docker `ENTRYPOINT` listens on port `12111` for HTTP and `12112`


### PR DESCRIPTION
The previous command forwarded port 12111 (HTTP) on the host machine to port
12112 (HTTPS) inside the container. That would mean you wouldn't be able to hit
the service over HTTP.

This changes the command to use a port range of 12111-12112 on both sides so
both the HTTP and HTTPS port will be available.