### PR TITLE
Coerce values within an object within an `anyOf`

### DIFF
--- a/param/coercer/coercer.go
+++ b/param/coercer/coercer.go
@@ -136,11 +136,21 @@ func coercePrimitiveType(val interface{}, primitiveType string) (interface{}, bo
 func coerceSchema(val interface{}, schema *spec.Schema) (interface{}, bool) {
 	if isSchemaPrimitiveType(schema) {
 		return coercePrimitiveType(val, schema.Type)
-	} else if schema.AnyOf != nil {
+	}
+
+	if schema.AnyOf != nil {
 		for _, subSchema := range schema.AnyOf {
-			val, ok := coerceSchema(val, subSchema)
-			if ok {
-				return val, ok
+			if isSchemaPrimitiveType(subSchema) {
+				val, ok := coerceSchema(val, subSchema)
+				if ok {
+					return val, ok
+				}
+			} else {
+				valMap, ok := val.(map[string]interface{})
+				if ok {
+					CoerceParams(subSchema, valMap)
+					return valMap, ok
+				}
 			}
 		}
 	}

--- a/param/coercer/coercer_test.go
+++ b/param/coercer/coercer_test.go
@@ -8,21 +8,47 @@ import (
 )
 
 func TestCoerceParams_AnyOfCoercion(t *testing.T) {
-	schema := &spec.Schema{Properties: map[string]*spec.Schema{
-		"objectorintkey": {
-			AnyOf: []*spec.Schema{
-				{Type: objectType},
-				{Type: integerType},
+	// `anyOf` with basic types
+	{
+		schema := &spec.Schema{Properties: map[string]*spec.Schema{
+			"bool_or_int_key": {
+				AnyOf: []*spec.Schema{
+					{Type: objectType},
+					{Type: integerType},
+				},
 			},
-		},
-	}}
-	data := map[string]interface{}{
-		"objectorintkey": "123",
+		}}
+		data := map[string]interface{}{
+			"bool_or_int_key": "123",
+		}
+
+		err := CoerceParams(schema, data)
+		assert.NoError(t, err)
+		assert.Equal(t, 123, data["bool_or_int_key"])
 	}
 
-	err := CoerceParams(schema, data)
-	assert.NoError(t, err)
-	assert.Equal(t, 123, data["objectorintkey"])
+	// `anyOf` with object type
+	{
+		schema := &spec.Schema{Properties: map[string]*spec.Schema{
+			"object_or_int_key": {
+				AnyOf: []*spec.Schema{
+					{Properties: map[string]*spec.Schema{
+						"intkey": {Type: integerType},
+					}},
+					{Type: integerType},
+				},
+			},
+		}}
+		data := map[string]interface{}{
+			"object_or_int_key": map[string]interface{}{
+				"intkey": 123,
+			},
+		}
+
+		err := CoerceParams(schema, data)
+		assert.NoError(t, err)
+		assert.Equal(t, 123, data["object_or_int_key"].(map[string]interface{})["intkey"])
+	}
 }
 
 func TestCoerceParams_ArrayCoercion(t *testing.T) {


### PR DESCRIPTION
As described in #95, there's currently a problem with the coercer in
that if it finds an `anyOf`, it assumes that only primitive schema types
like a `boolean` or `integer` will be present in it.

This isn't true -- it somes cases (say `destination` while creating a
charge), it's possible to have an object _or_ a primitive type. In the
case of the object, stripe-mock wouldn't error, but would also not
coerce anything within it, and therefore requests might fail validation.

Here we consider that an object might be found as welll, and implement
code to handle that case.

Fixes #95.