### PR TITLE
Fix test to match naming + less aggressive parameter coercion

### DIFF
--- a/param/coercer/coercer.go
+++ b/param/coercer/coercer.go
@@ -105,21 +105,21 @@ func coercePrimitiveType(val interface{}, primitiveType string) (interface{}, bo
 	case primitiveType == booleanType:
 		valBool, err := strconv.ParseBool(valStr)
 		if err != nil {
-			valBool = false
+			return nil, false
 		}
 		return valBool, true
 
 	case primitiveType == integerType:
 		valInt, err := strconv.Atoi(valStr)
 		if err != nil {
-			valInt = 0
+			return nil, false
 		}
 		return valInt, true
 
 	case primitiveType == numberType:
 		valFloat, err := strconv.ParseFloat(valStr, 64)
 		if err != nil {
-			valFloat = 0.0
+			return nil, false
 		}
 		return valFloat, true
 	}

--- a/param/coercer/coercer_test.go
+++ b/param/coercer/coercer_test.go
@@ -13,7 +13,7 @@ func TestCoerceParams_AnyOfCoercion(t *testing.T) {
 		schema := &spec.Schema{Properties: map[string]*spec.Schema{
 			"bool_or_int_key": {
 				AnyOf: []*spec.Schema{
-					{Type: objectType},
+					{Type: booleanType},
 					{Type: integerType},
 				},
 			},


### PR DESCRIPTION
Remi saw on #97 that I'd renamed a field to `bool_or_int_key` intending
to change a test, but I'd accidentally forgotten to make that subsequent
change, which was to create a higher fidelity test by testing two
primitive type schemas within the same `anyOf`.

Here I made that change, but noticed when I did it that the tests
started to fail. It turned out this is because we were coercing
primitive types overly aggressively. If for example a boolean schema
received an integer like `123`, `strconv.ParseBool` would fail with an
error, but we'd just default to the value `false`.

In this test, it had the effect of the `anyOf` taking the first boolean
branch, even though the value is much better suited to be coerced to an
integer.

Here we relax primitive type coercion. If a value can be parsed for that
type, it is, but if it's not, we default to the value that was given to
us. This seems like a better fit for the coercion behavior that we
actually want.

r? @remi-stripe