### PR TITLE
Improve test setup

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,14 +37,14 @@ func main() {
 	}
 
 	flag.BoolVar(&options.http, "http", false, "Run with HTTP")
-	flag.IntVar(&options.httpPort, "http-port", 0, "Port to listen on for HTTP")
+	flag.IntVar(&options.httpPort, "http-port", -1, "Port to listen on for HTTP")
 	flag.StringVar(&options.httpUnixSocket, "http-unix", "", "Unix socket to listen on for HTTP")
 
 	flag.BoolVar(&options.https, "https", false, "Run with HTTPS (which also allows HTTP/2 to be activated)")
-	flag.IntVar(&options.httpsPort, "https-port", 0, "Port to listen on for HTTPS")
+	flag.IntVar(&options.httpsPort, "https-port", -1, "Port to listen on for HTTPS")
 	flag.StringVar(&options.httpsUnixSocket, "https-unix", "", "Unix socket to listen on for HTTPS")
 
-	flag.IntVar(&options.port, "port", 0, "Port to listen on (also respects PORT from environment)")
+	flag.IntVar(&options.port, "port", -1, "Port to listen on (also respects PORT from environment)")
 	flag.StringVar(&options.fixturesPath, "fixtures", "", "Path to fixtures to use instead of bundled version (should be JSON)")
 	flag.StringVar(&options.specPath, "spec", "", "Path to OpenAPI spec to use instead of bundled version (should be JSON)")
 	flag.StringVar(&options.unixSocket, "unix", "", "Unix socket to listen on")
@@ -174,7 +174,7 @@ type options struct {
 }
 
 func (o *options) checkConflictingOptions() error {
-	if o.unixSocket != "" && o.port != 0 {
+	if o.unixSocket != "" && o.port != -1 {
 		return fmt.Errorf("Please specify only one of -port or -unix")
 	}
 
@@ -182,15 +182,15 @@ func (o *options) checkConflictingOptions() error {
 	// HTTP
 	//
 
-	if o.http && (o.httpUnixSocket != "" || o.httpPort != 0) {
+	if o.http && (o.httpUnixSocket != "" || o.httpPort != -1) {
 		return fmt.Errorf("Please don't specify -http when using -http-port or -http-unix")
 	}
 
-	if (o.unixSocket != "" || o.port != 0) && (o.httpUnixSocket != "" || o.httpPort != 0) {
+	if (o.unixSocket != "" || o.port != -1) && (o.httpUnixSocket != "" || o.httpPort != -1) {
 		return fmt.Errorf("Please don't specify -port or -unix when using -http-port or -http-unix")
 	}
 
-	if o.httpUnixSocket != "" && o.httpPort != 0 {
+	if o.httpUnixSocket != "" && o.httpPort != -1 {
 		return fmt.Errorf("Please specify only one of -http-port or -http-unix")
 	}
 
@@ -198,15 +198,15 @@ func (o *options) checkConflictingOptions() error {
 	// HTTPS
 	//
 
-	if o.https && (o.httpsUnixSocket != "" || o.httpsPort != 0) {
+	if o.https && (o.httpsUnixSocket != "" || o.httpsPort != -1) {
 		return fmt.Errorf("Please don't specify -https when using -https-port or -https-unix")
 	}
 
-	if (o.unixSocket != "" || o.port != 0) && (o.httpsUnixSocket != "" || o.httpsPort != 0) {
+	if (o.unixSocket != "" || o.port != -1) && (o.httpsUnixSocket != "" || o.httpsPort != -1) {
 		return fmt.Errorf("Please don't specify -port or -unix when using -https-port or -https-unix")
 	}
 
-	if o.httpsUnixSocket != "" && o.httpsPort != 0 {
+	if o.httpsUnixSocket != "" && o.httpsPort != -1 {
 		return fmt.Errorf("Please specify only one of -https-port or -https-unix")
 	}
 
@@ -218,7 +218,7 @@ func (o *options) checkConflictingOptions() error {
 func (o *options) getHTTPListener() (net.Listener, error) {
 	protocol := "HTTP"
 
-	if o.httpPort != 0 {
+	if o.httpPort != -1 {
 		return getPortListener(o.httpPort, protocol)
 	}
 
@@ -228,11 +228,11 @@ func (o *options) getHTTPListener() (net.Listener, error) {
 
 	// HTTPS is active by default, but only if HTTP has not been explicitly
 	// activated.
-	if o.https || o.httpsPort != 0 || o.httpsUnixSocket != "" {
+	if o.https || o.httpsPort != -1 || o.httpsUnixSocket != "" {
 		return nil, nil
 	}
 
-	if o.port != 0 {
+	if o.port != -1 {
 		return getPortListener(o.port, protocol)
 	}
 
@@ -249,7 +249,7 @@ func (o *options) getHTTPListener() (net.Listener, error) {
 func (o *options) getNonSecureHTTPSListener() (net.Listener, error) {
 	protocol := "HTTPS"
 
-	if o.httpsPort != 0 {
+	if o.httpsPort != -1 {
 		return getPortListener(o.httpsPort, protocol)
 	}
 
@@ -259,11 +259,11 @@ func (o *options) getNonSecureHTTPSListener() (net.Listener, error) {
 
 	// HTTPS is active by default, but only if HTTP has not been explicitly
 	// activated.
-	if o.http || o.httpPort != 0 || o.httpUnixSocket != "" {
+	if o.http || o.httpPort != -1 || o.httpUnixSocket != "" {
 		return nil, nil
 	}
 
-	if o.port != 0 {
+	if o.port != -1 {
 		return getPortListener(o.port, protocol)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -188,50 +188,58 @@ func initTestSpec() {
 	}
 }
 
+func getDefaultOptions() *options {
+	return &options{
+		httpPort:  -1,
+		httpsPort: -1,
+		port:      -1,
+	}
+}
+
 func TestCheckConflictingOptions(t *testing.T) {
 	//
 	// Valid sets of options (not exhaustive, but included quite a few standard invocations)
 	//
 
 	{
-		options := &options{
-			http: true,
-		}
+		options := getDefaultOptions()
+		options.http = true
+
 		err := options.checkConflictingOptions()
 		assert.NoError(t, err)
 	}
 
 	{
-		options := &options{
-			https: true,
-		}
+		options := getDefaultOptions()
+		options.https = true
+
 		err := options.checkConflictingOptions()
 		assert.NoError(t, err)
 	}
 
 	{
-		options := &options{
-			https: true,
-			port:  12111,
-		}
+		options := getDefaultOptions()
+		options.https = true
+		options.port = 12111
+
 		err := options.checkConflictingOptions()
 		assert.NoError(t, err)
 	}
 
 	{
-		options := &options{
-			httpPort:  12111,
-			httpsPort: 12112,
-		}
+		options := getDefaultOptions()
+		options.httpPort = 12111
+		options.httpsPort = 12111
+
 		err := options.checkConflictingOptions()
 		assert.NoError(t, err)
 	}
 
 	{
-		options := &options{
-			httpUnixSocket:  "/tmp/stripe-mock.sock",
-			httpsUnixSocket: "/tmp/stripe-mock-secure.sock",
-		}
+		options := getDefaultOptions()
+		options.httpUnixSocket = "/tmp/stripe-mock.sock"
+		options.httpsUnixSocket = "/tmp/stripe-mock-secure.sock"
+
 		err := options.checkConflictingOptions()
 		assert.NoError(t, err)
 	}
@@ -241,10 +249,10 @@ func TestCheckConflictingOptions(t *testing.T) {
 	//
 
 	{
-		options := &options{
-			port:       12111,
-			unixSocket: "/tmp/stripe-mock.sock",
-		}
+		options := getDefaultOptions()
+		options.port = 12111
+		options.unixSocket = "/tmp/stripe-mock.sock"
+
 		err := options.checkConflictingOptions()
 		assert.Equal(t, fmt.Errorf("Please specify only one of -port or -unix"), err)
 	}
@@ -254,46 +262,46 @@ func TestCheckConflictingOptions(t *testing.T) {
 	//
 
 	{
-		options := &options{
-			http:     true,
-			httpPort: 12111,
-		}
+		options := getDefaultOptions()
+		options.http = true
+		options.httpPort = 12111
+
 		err := options.checkConflictingOptions()
 		assert.Equal(t, fmt.Errorf("Please don't specify -http when using -http-port or -http-unix"), err)
 	}
 
 	{
-		options := &options{
-			http:           true,
-			httpUnixSocket: "/tmp/stripe-mock.sock",
-		}
+		options := getDefaultOptions()
+		options.http = true
+		options.httpUnixSocket = "/tmp/stripe-mock.sock"
+
 		err := options.checkConflictingOptions()
 		assert.Equal(t, fmt.Errorf("Please don't specify -http when using -http-port or -http-unix"), err)
 	}
 
 	{
-		options := &options{
-			port:     12111,
-			httpPort: 12111,
-		}
+		options := getDefaultOptions()
+		options.port = 12111
+		options.httpPort = 12111
+
 		err := options.checkConflictingOptions()
 		assert.Equal(t, fmt.Errorf("Please don't specify -port or -unix when using -http-port or -http-unix"), err)
 	}
 
 	{
-		options := &options{
-			unixSocket:     "/tmp/stripe-mock.sock",
-			httpUnixSocket: "/tmp/stripe-mock.sock",
-		}
+		options := getDefaultOptions()
+		options.unixSocket = "/tmp/stripe-mock.sock"
+		options.httpUnixSocket = "/tmp/stripe-mock.sock"
+
 		err := options.checkConflictingOptions()
 		assert.Equal(t, fmt.Errorf("Please don't specify -port or -unix when using -http-port or -http-unix"), err)
 	}
 
 	{
-		options := &options{
-			httpPort:       12111,
-			httpUnixSocket: "/tmp/stripe-mock.sock",
-		}
+		options := getDefaultOptions()
+		options.httpPort = 12111
+		options.httpUnixSocket = "/tmp/stripe-mock.sock"
+
 		err := options.checkConflictingOptions()
 		assert.Equal(t, fmt.Errorf("Please specify only one of -http-port or -http-unix"), err)
 	}
@@ -303,61 +311,59 @@ func TestCheckConflictingOptions(t *testing.T) {
 	//
 
 	{
-		options := &options{
-			https:     true,
-			httpsPort: 12111,
-		}
+		options := getDefaultOptions()
+		options.https = true
+		options.httpsPort = 12111
+
 		err := options.checkConflictingOptions()
 		assert.Equal(t, fmt.Errorf("Please don't specify -https when using -https-port or -https-unix"), err)
 	}
 
 	{
-		options := &options{
-			https:           true,
-			httpsUnixSocket: "/tmp/stripe-mock.sock",
-		}
+		options := getDefaultOptions()
+		options.https = true
+		options.httpsUnixSocket = "/tmp/stripe-mock.sock"
+
 		err := options.checkConflictingOptions()
 		assert.Equal(t, fmt.Errorf("Please don't specify -https when using -https-port or -https-unix"), err)
 	}
 
 	{
-		options := &options{
-			port:      12111,
-			httpsPort: 12111,
-		}
+		options := getDefaultOptions()
+		options.port = 12111
+		options.httpsPort = 12111
+
 		err := options.checkConflictingOptions()
 		assert.Equal(t, fmt.Errorf("Please don't specify -port or -unix when using -https-port or -https-unix"), err)
 	}
 
 	{
-		options := &options{
-			unixSocket:      "/tmp/stripe-mock.sock",
-			httpsUnixSocket: "/tmp/stripe-mock.sock",
-		}
+		options := getDefaultOptions()
+		options.unixSocket = "/tmp/stripe-mock.sock"
+		options.httpsUnixSocket = "/tmp/stripe-mock.sock"
+
 		err := options.checkConflictingOptions()
 		assert.Equal(t, fmt.Errorf("Please don't specify -port or -unix when using -https-port or -https-unix"), err)
 	}
 
 	{
-		options := &options{
-			httpsPort:       12111,
-			httpsUnixSocket: "/tmp/stripe-mock.sock",
-		}
+		options := getDefaultOptions()
+		options.httpsPort = 12111
+		options.httpsUnixSocket = "/tmp/stripe-mock.sock"
+
 		err := options.checkConflictingOptions()
 		assert.Equal(t, fmt.Errorf("Please specify only one of -https-port or -https-unix"), err)
 	}
 }
 
-// I didn't find a particularly easy way of asking for a free port in Go, so
-// here we just pick one in a high range that's unlikely to conflict with
-// anything else.
-const hopefullyFreePort = 32983
+// Specify :0 to ask the OS for a free port.
+const freePort = 0
 
 func TestOptionsGetHTTPListener(t *testing.T) {
 	// Gets a listener when explicitly requested.
 	{
 		options := &options{
-			httpPort: hopefullyFreePort,
+			httpPort: freePort,
 		}
 		listener, err := options.getHTTPListener()
 		assert.NoError(t, err)
@@ -368,7 +374,8 @@ func TestOptionsGetHTTPListener(t *testing.T) {
 	// No listener when HTTPS is explicitly requested, but HTTP is not.
 	{
 		options := &options{
-			httpsPort: hopefullyFreePort,
+			httpPort:  -1, // Signals not specified
+			httpsPort: freePort,
 		}
 		listener, err := options.getHTTPListener()
 		assert.NoError(t, err)
@@ -378,7 +385,7 @@ func TestOptionsGetHTTPListener(t *testing.T) {
 	// Activates on the default HTTP port if no other args provided.
 	{
 		options := &options{
-			httpPortDefault: hopefullyFreePort,
+			httpPortDefault: freePort,
 		}
 		listener, err := options.getHTTPListener()
 		assert.NoError(t, err)
@@ -391,7 +398,7 @@ func TestOptionsGetNonSecureHTTPSListener(t *testing.T) {
 	// Gets a listener when explicitly requested.
 	{
 		options := &options{
-			httpsPort: hopefullyFreePort,
+			httpsPort: freePort,
 		}
 		listener, err := options.getNonSecureHTTPSListener()
 		assert.NoError(t, err)
@@ -402,7 +409,8 @@ func TestOptionsGetNonSecureHTTPSListener(t *testing.T) {
 	// No listener when HTTP is explicitly requested, but HTTPS is not.
 	{
 		options := &options{
-			httpPort: hopefullyFreePort,
+			httpPort:  freePort,
+			httpsPort: -1, // Signals not specified
 		}
 		listener, err := options.getNonSecureHTTPSListener()
 		assert.NoError(t, err)
@@ -412,7 +420,7 @@ func TestOptionsGetNonSecureHTTPSListener(t *testing.T) {
 	// Activates on the default HTTPS port if no other args provided.
 	{
 		options := &options{
-			httpsPortDefault: hopefullyFreePort,
+			httpsPortDefault: freePort,
 		}
 		listener, err := options.getNonSecureHTTPSListener()
 		assert.NoError(t, err)


### PR DESCRIPTION
Previously the listener tests depended on a hard-coded port that we
hoped was free. Here we change the strategy slightly to ask the OS for a
free port with `:0`.

Unfortunately, that means also changing some code elsewhere because we
were previously relying on `0` to signify an empty argument. We now
change that to `-1` and update code and tests.