### PR TITLE
Don't start `HTTPS` with `-port` option specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -258,8 +258,10 @@ func (o *options) getNonSecureHTTPSListener() (net.Listener, error) {
 	}
 
 	// HTTPS is active by default, but only if HTTP has not been explicitly
-	// activated.
-	if o.http || o.httpPort != -1 || o.httpUnixSocket != "" {
+	// activated. HTTP may be activated with `-http`, `-http-port`, or
+	// `-http-unix`, but also with the old backwards compatible basic `-port`
+	// option.
+	if o.http || o.httpPort != -1 || o.httpUnixSocket != "" || o.port != -1 {
 		return nil, nil
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -417,6 +417,18 @@ func TestOptionsGetNonSecureHTTPSListener(t *testing.T) {
 		assert.Nil(t, listener)
 	}
 
+	// No listener when HTTP is explicitly requested with the old `-port`
+	// option.
+	{
+		options := &options{
+			httpsPort: -1, // Signals not specified
+			port:      freePort,
+		}
+		listener, err := options.getNonSecureHTTPSListener()
+		assert.NoError(t, err)
+		assert.Nil(t, listener)
+	}
+
 	// Activates on the default HTTPS port if no other args provided.
 	{
 		options := &options{


### PR DESCRIPTION
I recently did a lot of refactoring for the arguments so that we start
both HTTP and HTTPS by default.

One place where we don't start both of them is if either HTTP or HTTPS
is explicitly requested but the other is not.

This mostly worked, but I forgot to account for the old `-port` option,
which is taken to be an alias for `-http-port`. Like with `-http-port`,
if it's specified but HTTPS is not requested, we start HTTP only. This
patch now accounts for that.