### PR TITLE
Add support for query parameters on `GET` endpoints

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -13,8 +13,8 @@ var applicationFeeRefundCreateMethod *spec.Operation
 var applicationFeeRefundGetMethod *spec.Operation
 var chargeAllMethod *spec.Operation
 var chargeCreateMethod *spec.Operation
-var chargeDeleteMethod *spec.Operation
 var chargeGetMethod *spec.Operation
+var customerDeleteMethod *spec.Operation
 var invoicePayMethod *spec.Operation
 
 // Try to avoid using the real spec as much as possible because it's more
@@ -116,7 +116,9 @@ func initTestSpec() {
 			},
 		},
 	}
-	chargeDeleteMethod = &spec.Operation{
+	chargeGetMethod = &spec.Operation{}
+
+	customerDeleteMethod = &spec.Operation{
 		RequestBody: &spec.RequestBody{
 			Content: map[string]spec.MediaType{
 				"application/x-www-form-urlencoded": {
@@ -132,14 +134,13 @@ func initTestSpec() {
 				Content: map[string]spec.MediaType{
 					"application/json": {
 						Schema: &spec.Schema{
-							Ref: "#/components/schemas/charge",
+							Ref: "#/components/schemas/deleted_customer",
 						},
 					},
 				},
 			},
 		},
 	}
-	chargeGetMethod = &spec.Operation{}
 
 	// Here so we can test the relatively rare "action" operations (e.g.,
 	// `POST` to `/pay` on an invoice).
@@ -210,8 +211,10 @@ func initTestSpec() {
 				"post": chargeCreateMethod,
 			},
 			spec.Path("/v1/charges/{id}"): {
-				"get":    chargeGetMethod,
-				"delete": chargeDeleteMethod,
+				"get": chargeGetMethod,
+			},
+			spec.Path("/v1/customers/{id}"): {
+				"delete": customerDeleteMethod,
 			},
 			spec.Path("/v1/invoices/{id}/pay"): {
 				"post": invoicePayMethod,

--- a/main_test.go
+++ b/main_test.go
@@ -65,7 +65,29 @@ func initTestSpec() {
 	applicationFeeRefundCreateMethod = &spec.Operation{}
 	applicationFeeRefundGetMethod = &spec.Operation{}
 
-	chargeAllMethod = &spec.Operation{}
+	chargeAllMethod = &spec.Operation{
+		Parameters: []*spec.Parameter{
+			{
+				In:       spec.ParameterQuery,
+				Name:     "limit",
+				Required: false,
+				Schema: &spec.Schema{
+					Type: spec.TypeInteger,
+				},
+			},
+		},
+		Responses: map[spec.StatusCode]spec.Response{
+			"200": {
+				Content: map[string]spec.MediaType{
+					"application/json": {
+						Schema: &spec.Schema{
+							Type: spec.TypeObject,
+						},
+					},
+				},
+			},
+		},
+	}
 	chargeCreateMethod = &spec.Operation{
 		RequestBody: &spec.RequestBody{
 			Content: map[string]spec.MediaType{
@@ -74,7 +96,7 @@ func initTestSpec() {
 						AdditionalProperties: false,
 						Properties: map[string]*spec.Schema{
 							"amount": {
-								Type: "integer",
+								Type: spec.TypeInteger,
 							},
 						},
 						Required: []string{"amount"},
@@ -95,6 +117,16 @@ func initTestSpec() {
 		},
 	}
 	chargeDeleteMethod = &spec.Operation{
+		RequestBody: &spec.RequestBody{
+			Content: map[string]spec.MediaType{
+				"application/x-www-form-urlencoded": {
+					Schema: &spec.Schema{
+						AdditionalProperties: false,
+						Type:                 spec.TypeObject,
+					},
+				},
+			},
+		},
 		Responses: map[spec.StatusCode]spec.Response{
 			"200": {
 				Content: map[string]spec.MediaType{

--- a/param/param.go
+++ b/param/param.go
@@ -10,6 +10,10 @@ import (
 	"github.com/stripe/stripe-mock/param/parser"
 )
 
+//
+// Public functions
+//
+
 // ParseParams extracts parameters from a request that an application can
 // consume.
 //

--- a/server_test.go
+++ b/server_test.go
@@ -67,6 +67,34 @@ func TestStubServer_ExtraParam(t *testing.T) {
 	assert.Contains(t, message, "additional properties are not allowed: doesntexist")
 }
 
+func TestStubServer_QueryParam(t *testing.T) {
+	resp, body := sendRequest(t, "GET", "/v1/charges?limit=10",
+		"", getDefaultHeaders())
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var data map[string]interface{}
+	err := json.Unmarshal(body, &data)
+	assert.NoError(t, err)
+}
+
+func TestStubServer_QueryExtraParam(t *testing.T) {
+	resp, body := sendRequest(t, "GET", "/v1/charges?limit=10&doesntexist=foo",
+		"", getDefaultHeaders())
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	var data map[string]interface{}
+	err := json.Unmarshal(body, &data)
+	assert.NoError(t, err)
+	errorInfo, ok := data["error"].(map[string]interface{})
+	assert.True(t, ok)
+	errorType, ok := errorInfo["type"]
+	assert.Equal(t, errorType, "invalid_request_error")
+	assert.True(t, ok)
+	message, ok := errorInfo["message"]
+	assert.True(t, ok)
+	assert.Contains(t, message, "additional properties are not allowed: doesntexist")
+}
+
 func TestStubServer_InvalidAuthorization(t *testing.T) {
 	resp, body := sendRequest(t, "GET", "/a", "", nil)
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)

--- a/server_test.go
+++ b/server_test.go
@@ -174,7 +174,7 @@ func TestStubServer_AllowsEmptyContentTypeOnDelete(t *testing.T) {
 	headers := getDefaultHeaders()
 	headers["Content-Type"] = ""
 
-	resp, _ := sendRequest(t, "DELETE", "/v1/charges/ch_123", "", headers)
+	resp, _ := sendRequest(t, "DELETE", "/v1/customers/cus_123", "", headers)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
@@ -239,10 +239,10 @@ func TestStubServer_RoutesRequest(t *testing.T) {
 
 	{
 		route, pathParams := server.routeRequest(
-			&http.Request{Method: "DELETE", URL: &url.URL{Path: "/v1/charges/ch_123"}})
+			&http.Request{Method: "DELETE", URL: &url.URL{Path: "/v1/customers/cus_123"}})
 		assert.NotNil(t, route)
-		assert.Equal(t, chargeDeleteMethod, route.operation)
-		assert.Equal(t, "ch_123", *(*pathParams).PrimaryID)
+		assert.Equal(t, customerDeleteMethod, route.operation)
+		assert.Equal(t, "cus_123", *(*pathParams).PrimaryID)
 		assert.Equal(t, []*PathParamsSecondaryID(nil), (*pathParams).SecondaryIDs)
 	}
 

--- a/spec/query.go
+++ b/spec/query.go
@@ -1,0 +1,35 @@
+package spec
+
+// BuildQuerySchema builds a JSON schema that will be used to validate query
+// parameters on the incoming request. Unlike request bodies, OpenAPI puts
+// query parameters in a different, non-JSON schema part of an operation.
+func BuildQuerySchema(operation *Operation) *Schema {
+	schema := &Schema{
+		AdditionalProperties: false,
+		Properties:           make(map[string]*Schema),
+		Required:             make([]string, 0),
+		Type:                 TypeObject,
+	}
+
+	if operation.Parameters == nil {
+		return schema
+	}
+
+	for _, param := range operation.Parameters {
+		if param.In != ParameterQuery {
+			continue
+		}
+
+		paramSchema := param.Schema
+		if paramSchema == nil {
+			paramSchema = &Schema{Type: TypeObject}
+		}
+		schema.Properties[param.Name] = paramSchema
+
+		if param.Required {
+			schema.Required = append(schema.Required, param.Name)
+		}
+	}
+
+	return schema
+}

--- a/spec/query_test.go
+++ b/spec/query_test.go
@@ -1,0 +1,82 @@
+package spec
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestBuildQuerySchema(t *testing.T) {
+	// Handles a normal case
+	{
+		operation := &Operation{
+			Parameters: []*Parameter{
+				{
+					In:   ParameterQuery,
+					Name: "name",
+					Schema: &Schema{
+						Type: TypeString,
+					},
+				},
+			},
+		}
+		schema := BuildQuerySchema(operation)
+
+		assert.Equal(t, false, schema.AdditionalProperties)
+		assert.Equal(t, 1, len(schema.Properties))
+		assert.Equal(t, 0, len(schema.Required))
+
+		paramSchema := schema.Properties["name"]
+		assert.Equal(t, TypeString, paramSchema.Type)
+	}
+
+	// A non-query parameter
+	{
+		operation := &Operation{
+			Parameters: []*Parameter{
+				{
+					In:   ParameterPath,
+					Name: "name",
+				},
+			},
+		}
+		schema := BuildQuerySchema(operation)
+
+		assert.Equal(t, 0, len(schema.Properties))
+	}
+
+	// A required parameter
+	{
+		operation := &Operation{
+			Parameters: []*Parameter{
+				{
+					In:       ParameterQuery,
+					Name:     "name",
+					Required: true,
+					Schema: &Schema{
+						Type: TypeString,
+					},
+				},
+			},
+		}
+		schema := BuildQuerySchema(operation)
+
+		assert.Equal(t, []string{"name"}, schema.Required)
+	}
+
+	// A query parameter with no schema
+	{
+		operation := &Operation{
+			Parameters: []*Parameter{
+				{
+					In:   ParameterQuery,
+					Name: "name",
+				},
+			},
+		}
+		schema := BuildQuerySchema(operation)
+
+		paramSchema := schema.Properties["name"]
+		assert.Equal(t, TypeObject, paramSchema.Type)
+	}
+}

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -9,6 +9,12 @@ import (
 // Public values
 //
 
+// A set of constants for the different types of possible OpenAPI parameters.
+const (
+	ParameterPath  = "path"
+	ParameterQuery = "query"
+)
+
 // A set of constant for the named types available in JSON Schema.
 const (
 	TypeArray   = "array"


### PR DESCRIPTION
Add support for validating query parameters on `GET` endpoints
(Non-`GET` endpoints always add all their parameters into the request
body schema in OpenAPI, so we don't have to worry about supporting
them.)

A little bit of background: when generating OpenAPI, we use a simplified
logic that puts parameters for `GET` endpoints in as query parameters,
and puts the parameters for all other types of endpoint in as request
body parameters. This is not exactly right because all endpoints will
read either type of parameter, but it makes things look a little more
correct because convention is to always use query strings on `GET`
endpoints (e.g., `GET /v1/charges?limit=3`).

In stripe-mock, I initially skipped over implementing any kind of
validation on query string parameters because they're not as important
to validate, and it was more code to write. Unfortunately, that
omission carried through all the way to the present day.

When I put stronger extra parameter validation into the OpenAPI spec, it
revealed a problem where stripe-mock was refusing query string
parameters on `GET` endpoints because they weren't in the request body
schema, and it didn't know how to handle the query string parameter
definitions. This is why stripe-ruby's test suite fails against the
latest version of stripe-mock.

Here I add support for query parameters using a simple method that
converts their OpenAPI definitions into a JSON schema so we can use a
similar method to validate them as we do for request bodies.

So here are the basic rules:

1. In OpenAPI `GET` endpoints only specify query parameters.
2. In OpenAPI, non-`GET` endpoints only specify request body schemas.
3. When validating a `GET`, only the query string is considered (an HTTP
   RFC suggests that request bodies on `GET` are semantically
   meaningless, so this is consistent with that, but more importantly, I
   think it'll be a useful simplification for our purposes).
4. When validating non-`GET`, both the query string and request body are
   parsed.

I suspect there might still be some other subtle problem that I haven't
considered yet, but this seems to be a big improvement over what we have
today. I'm able to run the entire stripe-ruby test suite against it with
no failures, and it even caught a few problems in stripe-ruby's test
suite [1].

r? @remi-stripe Sorry I know this is a lot of code to look at, but mind
commenting at least on the high-level design? I'm mostly interested in getting
the latest version of stripe-mock working against our library test suites
again.

cc @stripe/api-libraries

[1] https://github.com/stripe/stripe-ruby/pull/679