### PR TITLE
Create tags for Docker Hub releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ script:
 
   # Build and test the Docker image. It's pushed to Docker Hub as part of the
   # deploy phase.
-  - docker build -t "$DOCKER_REPO" .
-  - docker run -d --name stripe-mock-container -p 12111:12111 "$DOCKER_REPO"
+  - docker build -t "$DOCKER_REPO:${TRAVIS_COMMIT:0:8}" .
+  - docker run -d --name stripe-mock-container -p 12111:12111 "$DOCKER_REPO:${TRAVIS_COMMIT:0:8}"
   - docker ps -a
 
 deploy:

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -7,4 +7,16 @@
 #     https://docs.travis-ci.com/user/docker/
 
 docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
+
+# $TRAVIS_TAG contains a tag if this is a build for a tag, otherwise it's
+# empty.
+#
+# Create Docker Hub tags for Git tags and keep one in place for the master
+# branch.
+if [ ! -z "$TRAVIS_TAG" ]; then
+    docker tag "$DOCKER_REPO:${TRAVIS_COMMIT:0:8}" "$DOCKER_REPO:$TRAVIS_TAG"
+elif [ "$TRAVIS_BRANCH" == "master"]; then
+    docker tag "$DOCKER_REPO:${TRAVIS_COMMIT:0:8}" "$DOCKER_REPO:master"
+fi
+
 docker push "$DOCKER_REPO"


### PR DESCRIPTION
Creates tags in Docker Hub for (1) the `master` branch when it's built,
and (2) for any builds for Git tags.

Fixes #110.

r? @remi-stripe The tagging only happens on master and tag builds so this might
take a little more finagling after I merge it. I cargo culted from someone
else's implementation, but there may still be something that doesn't work quite
right.