### PR TITLE
Add new "action" methods to ID replacement whitelist

### DIFF
--- a/server.go
+++ b/server.go
@@ -442,10 +442,14 @@ var hasPrimaryIDSuffixes = [...]string{
 	"/cancel",
 	"/close",
 	"/decline",
+	"/finalize",
+	"/mark_uncollectible",
 	"/pay",
 	"/refund",
 	"/reject",
+	"/send",
 	"/verify",
+	"/void",
 }
 
 var pathParameterPattern = regexp.MustCompile(`\{(\w+)\}`)


### PR DESCRIPTION
Okay, we have to get this whitelist eliminated, but here we add our new
"action-style" endpoints for now.

r? @remi-stripe