### PR TITLE
Add /release to the list of actions that can return a resource

### DIFF
--- a/server.go
+++ b/server.go
@@ -447,6 +447,7 @@ var hasPrimaryIDSuffixes = [...]string{
 	"/pay",
 	"/refund",
 	"/reject",
+	"/release",
 	"/send",
 	"/verify",
 	"/void",


### PR DESCRIPTION
An upcoming feature called Subscription Schedules have the /release action. stripe-mock has a list of those actions so that we know to replace the resource id with a fixture one instead.

r? @brandur-stripe 
cc @stripe/api-libraries 