### PR TITLE
Handle `anyOf` schema containing array in params coercer

### DIFF
--- a/param/coercer/coercer.go
+++ b/param/coercer/coercer.go
@@ -31,16 +31,17 @@ func CoerceParams(schema *spec.Schema, data map[string]interface{}) error {
 	return nil
 }
 
-// coerceSubSchema coerces sub-param value according to an arbitrary JSON sub-schema.
-// It is sub-schema because it can be array, primitive, or object,  unlike the main `CoerceParams`
-// only expecting object type with properties. This is also used in coercing each sub-schema
-// of anyOf or array.
+// coerceSubSchema coerces a sub-param value according to an arbitrary JSON sub-schema.
+// It is named with "sub-schema" because it can be array, primitive, or object, unlike the main
+// `CoerceParams` only expecting object type with properties. This is also used in coercing each
+// sub-schema of anyOf or array.
 func coerceSubSchema(val interface{}, subSchema *spec.Schema) (interface{}, bool, error) {
 	if len(subSchema.Properties) == 0 {
 		// Non-object schemas are anyOf, array, and primitive schemas.
 		// Implicitly treats actual object schema with empty properties as non-object.
 		return coerceNonObjectSchema(val, subSchema)
 	}
+
 	// `object` schema with properties
 	valMap, ok := val.(map[string]interface{})
 	var err error
@@ -61,8 +62,8 @@ const (
 	booleanType = "boolean"
 	integerType = "integer"
 	numberType  = "number"
-	stringType  = "string"
 	objectType  = "object"
+	stringType  = "string"
 )
 
 // maxSliceSize defines a somewhat arbitrary maximum size on an incoming

--- a/param/coercer/coercer.go
+++ b/param/coercer/coercer.go
@@ -19,12 +19,12 @@ func CoerceParams(schema *spec.Schema, data map[string]interface{}) error {
 		if !ok {
 			continue
 		}
-		val, ok, err := coerceSubSchema(val, subSchema)
+		coercedVal, ok, err := coerceSubSchema(val, subSchema)
 		if err != nil {
 			return err
 		}
 		if ok {
-			data[key] = val
+			data[key] = coercedVal
 		}
 	}
 
@@ -37,14 +37,15 @@ func CoerceParams(schema *spec.Schema, data map[string]interface{}) error {
 // of anyOf or array.
 func coerceSubSchema(val interface{}, subSchema *spec.Schema) (interface{}, bool, error) {
 	if len(subSchema.Properties) == 0 {
-		// anyOf, array, and primitive schemas
-		// additionalProperties without properties will not be coerced
+		// Non-object schemas are anyOf, array, and primitive schemas.
+		// Implicitly treats actual object schema with empty properties as non-object.
 		return coerceNonObjectSchema(val, subSchema)
 	}
-	// schema with properties with `object` type
+	// `object` schema with properties
 	valMap, ok := val.(map[string]interface{})
 	var err error
 	if ok {
+		// unwrapping sub-schemas, and coerce contents in the map
 		err = CoerceParams(subSchema, valMap)
 	}
 	return valMap, ok, err


### PR DESCRIPTION
- Currently stripe-mock doesn't expect array in `anyOf` schema. When it finds non-primitive sub-schema of `anyOf` it recurses using the main `CoerceParams` method. The method is used for top-level coercion, and assumes schema having properties. Because `Items` sub-schema for the array does not have properties, and it will get dropped. The output will remain as integer-indexed map value. For example, invoice update operation in OpenAPI has param for `custom_fields` as follows:
```
custom_fields:
  anyOf:
  - items:
      properties:
        // ...
      type: object
    type: array
  - enum:
    - ''
    type: string
```
and the resulting stripe-mock error is:
```
Request: POST /v1/invoices/in_123
Request data = map[custom_fields:map[0:map[value:val1 name:foo1] 1:map[name:foo2 value:val2]]]
Request validation error: validator 0xc000a182d0 failed: object property 'custom_fields' validation failed: could not validate against any of the constraints
```
- Verified that after this fix the output in stripe-mock is now
```
Request data = map[custom_fields:[map[name:foo1 value:val1] map[name:foo2 value:val2]]]
```
- The implementation introduces `coerceSubSchema` with different recurse behavior based on whether it is `object` schema. 
- The motivation here is when I'm testing for polymorphic params for java sdk-autogen and came across this issue.

r? @brandur-stripe 
cc @stripe/api-libraries 