### PR TITLE
Fix handling anyOf enum and number

### DIFF
--- a/param/coercer/coercer.go
+++ b/param/coercer/coercer.go
@@ -119,6 +119,15 @@ func coercePrimitiveType(val interface{}, primitiveType string) (interface{}, bo
 // also handles array and anyOf schema (supporting a number of different primitive types)
 func coerceNonObjectSchema(val interface{}, schema *spec.Schema) (interface{}, bool, error) {
 	if isSchemaPrimitiveType(schema) {
+		if schema.Enum != nil {
+			// assuming enum value isn't numeric string. when given anyOf schema with enum and
+			// number, the numeric string won't falsely be taken as enum and miss its coercion
+			_, isNumeric := coercePrimitiveType(val, numberType)
+			if isNumeric {
+				return nil, false, nil
+			}
+		}
+
 		val, ok := coercePrimitiveType(val, schema.Type)
 		return val, ok, nil
 	}

--- a/param/coercer/coercer_test.go
+++ b/param/coercer/coercer_test.go
@@ -134,9 +134,8 @@ func TestCoerceParams_AnyOfCoercion(t *testing.T) {
 				AnyOf: []*spec.Schema{
 					{Enum: []interface{}{
 						"enum1",
-						"enum2",
-					}, Type: stringType,
-					},
+						"enum2"},
+						Type: stringType},
 					{Type: integerType},
 				},
 			},


### PR DESCRIPTION
- This PR handles anyOf schema of integer and enum. The problem is any string input now satisfies Enum string-ness coercion; we don't actually check the specific type of enum (that is done later).
When given numeric string, it naively satisfies the enum as well, and the validator later complains that the numeric string isn't the integer type. The problematic schema is:
```
anyOf:
- enum:
  - inf
  maxLength: 5000
  type: string
- type: integer
```
- This isn't a problem before trying to handle anyOf Array and code structuring in this PR https://github.com/stripe/stripe-mock/pull/141/files because String isn't considered a primitive and always un-coerced, and thus numeric string will be always be considered as coercion candidate. 
- Looking at that PR again, string coercion helps to make `coerceSubSchema` return type consistent. 
Parsing sub-schema of AnyOf or Items can use "coerced" flag output consistently. 
- I can do code restructuring to consider String coerced, but I think it will be more complex than this additional assumption in this PR.
- This code will fail if we ever allow enum as numeric "123", "0.5" or if as "true"/"false"
cc @stripe/api-libraries 
