### PR TITLE
Add new API operations with custom words

### DIFF
--- a/server.go
+++ b/server.go
@@ -438,10 +438,13 @@ var hasPrimaryIDSuffixes = [...]string{
 	// These are resource "actions". They don't take the standard form, but we
 	// can expect an object's primary ID to live right before them in a path.
 	"/approve",
+	"/attach",
 	"/capture",
 	"/cancel",
 	"/close",
+	"/confirm",
 	"/decline",
+	"/detach",
 	"/finalize",
 	"/mark_uncollectible",
 	"/pay",


### PR DESCRIPTION
This adds new endpoints name that unblock test suites in our client libraries for new resources `PaymentIntent` and `PaymentMethod`.

r? @brandur-stripe 
cc @stripe/api-libraries 

We likely need a better way moving forward as we're committing to more and more "verb" actions though.