### PR TITLE
Add new option `-strict-version-check`

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 	flag.IntVar(&options.port, "port", -1, "Port to listen on (also respects PORT from environment)")
 	flag.StringVar(&options.fixturesPath, "fixtures", "", "Path to fixtures to use instead of bundled version (should be JSON)")
 	flag.StringVar(&options.specPath, "spec", "", "Path to OpenAPI spec to use instead of bundled version (should be JSON)")
+	flag.BoolVar(&options.strictVersionCheck, "strict-version-check", false, "Errors if version sent in Stripe-Version doesn't match the one in OpenAPI")
 	flag.StringVar(&options.unixSocket, "unix", "", "Unix socket to listen on")
 	flag.BoolVar(&verbose, "verbose", false, "Enable verbose mode")
 	flag.BoolVar(&options.showVersion, "version", false, "Show version and exit")
@@ -77,7 +78,11 @@ func main() {
 		abort(err.Error())
 	}
 
-	stub := StubServer{fixtures: fixtures, spec: stripeSpec}
+	stub := StubServer{
+		fixtures:           fixtures,
+		spec:               stripeSpec,
+		strictVersionCheck: options.strictVersionCheck,
+	}
 	err = stub.initializeRouter()
 	if err != nil {
 		abort(fmt.Sprintf("Error initializing router: %v\n", err))
@@ -167,10 +172,11 @@ type options struct {
 	httpsPort        int
 	httpsUnixSocket  string
 
-	port        int
-	showVersion bool
-	specPath    string
-	unixSocket  string
+	port               int
+	showVersion        bool
+	specPath           string
+	strictVersionCheck bool
+	unixSocket         string
 }
 
 func (o *options) checkConflictingOptions() error {

--- a/main_test.go
+++ b/main_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stripe/stripe-mock/spec"
 )
 
+const testSpecAPIVersion = "2019-01-01"
+
 var applicationFeeRefundCreateMethod *spec.Operation
 var applicationFeeRefundGetMethod *spec.Operation
 var chargeAllMethod *spec.Operation
@@ -163,6 +165,9 @@ func initTestSpec() {
 		}
 
 	testSpec = spec.Spec{
+		Info: &spec.Info{
+			Version: testSpecAPIVersion,
+		},
 		Components: spec.Components{
 			Schemas: map[string]*spec.Schema{
 				"charge": {

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -49,6 +49,14 @@ type Fixtures struct {
 // HTTPVerb is a type for an HTTP verb like GET, POST, etc.
 type HTTPVerb string
 
+// Info is the `info` portion of an OpenAPI specification that contains meta
+// information about it.
+type Info struct {
+	// Version is the Stripe API version represented in the specification. It
+	// takes a date-based form like `2019-02-19`.
+	Version string `json:"version"`
+}
+
 // This is a list of fields that either we handle properly or we're confident
 // it's safe to ignore. If a field not in this list appears in the OpenAPI spec,
 // then we'll get an error so we remember to update stripe-mock to support it.
@@ -201,6 +209,7 @@ type ResourceID string
 // Spec is a struct representing an OpenAPI specification.
 type Spec struct {
 	Components Components                       `json:"components"`
+	Info       *Info                            `json:"info"`
 	Paths      map[Path]map[HTTPVerb]*Operation `json:"paths"`
 }
 


### PR DESCRIPTION
Adds a new option called `-strict-version-check` that causes stripe-mock
to check that any value passed in an incoming request's `Stripe-Version`
header matches the version specified in the bundled OpenAPI
specification.

This is intended to act as an optionally strengthened expectation which
protects against an unintended drift between a bundled stripe-mock /
OpenAPI and the version being used from an API library. We'll likely
want to enable the option for static libraries like stripe-go and
stripe-dotnet.

r? @ob-stripe