### PR TITLE
Override file timestamps

### DIFF
--- a/bindata.go
+++ b/bindata.go
@@ -86,7 +86,7 @@ func certCertPem() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "cert/cert.pem", size: 1671, mode: os.FileMode(420), modTime: time.Unix(1573082524, 0)}
+	info := bindataFileInfo{name: "cert/cert.pem", size: 1671, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -106,7 +106,7 @@ func certKeyPem() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "cert/key.pem", size: 3272, mode: os.FileMode(420), modTime: time.Unix(1573082524, 0)}
+	info := bindataFileInfo{name: "cert/key.pem", size: 3272, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -126,7 +126,7 @@ func openapiOpenapiFixtures3Json() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "openapi/openapi/fixtures3.json", size: 77126, mode: os.FileMode(420), modTime: time.Unix(1573082654, 0)}
+	info := bindataFileInfo{name: "openapi/openapi/fixtures3.json", size: 77126, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -146,7 +146,7 @@ func openapiOpenapiSpec3Json() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "openapi/openapi/spec3.json", size: 2675735, mode: os.FileMode(420), modTime: time.Unix(1573082654, 0)}
+	info := bindataFileInfo{name: "openapi/openapi/spec3.json", size: 2675735, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-//go:generate go-bindata cert/cert.pem cert/key.pem openapi/openapi/fixtures3.json openapi/openapi/spec3.json
+//go:generate go-bindata -modtime 1 cert/cert.pem cert/key.pem openapi/openapi/fixtures3.json openapi/openapi/spec3.json
 
 package main
 


### PR DESCRIPTION
r? @ob-stripe 
cc @brandur-stripe 

Override file timestamps when using `go-bindata`, so the results are consistent across different systems (file modification times are not preserved by git).