### PR TITLE
Override file mode

### DIFF
--- a/bindata.go
+++ b/bindata.go
@@ -86,7 +86,7 @@ func certCertPem() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "cert/cert.pem", size: 1671, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "cert/cert.pem", size: 1671, mode: os.FileMode(444), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -106,7 +106,7 @@ func certKeyPem() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "cert/key.pem", size: 3272, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "cert/key.pem", size: 3272, mode: os.FileMode(444), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -126,7 +126,7 @@ func openapiOpenapiFixtures3Json() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "openapi/openapi/fixtures3.json", size: 77126, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "openapi/openapi/fixtures3.json", size: 77126, mode: os.FileMode(444), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -146,7 +146,7 @@ func openapiOpenapiSpec3Json() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "openapi/openapi/spec3.json", size: 2675735, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "openapi/openapi/spec3.json", size: 2675735, mode: os.FileMode(444), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-//go:generate go-bindata -modtime 1 cert/cert.pem cert/key.pem openapi/openapi/fixtures3.json openapi/openapi/spec3.json
+//go:generate go-bindata -mode 444 -modtime 1 cert/cert.pem cert/key.pem openapi/openapi/fixtures3.json openapi/openapi/spec3.json
 
 package main
 


### PR DESCRIPTION
r? @ob-stripe 
cc @brandur-stripe 

It turns out that the file mode can _also_ vary between environments. In this PR we're forcing them to 444, i.e. `r--r--r--`, i.e. read-only for everyone.
