### PR TITLE
Disable cgo in GoReleaser

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -6,6 +6,8 @@ before:
 
 builds:
   - binary: stripe-mock
+    env:
+      - CGO_ENABLED=0
     goos:
       - windows
       - darwin


### PR DESCRIPTION
r? @ob-stripe 
cc @brandur-stripe 

😭 So I think the Docker image I'm building locally works because:

> The cgo tool is enabled by default for native builds on systems where it is expected to work. It is disabled by default when cross-compiling.

(https://golang.org/cmd/cgo/)

So when building the Linux executable from my macOS laptop, it's cross-compiling so cgo is disabled. However, when Travis builds the Linux executable from a Linux container, it's a native build and cgo is enabled, resulting in an executable that doesn't work in the Alpine container.
