### PR TITLE
Allow `rk_` keys in addition to `sk_`

### DIFF
--- a/server.go
+++ b/server.go
@@ -778,7 +778,7 @@ func validateAuth(auth string) bool {
 		return false
 	}
 
-	if keyParts[0] != "sk" {
+	if keyParts[0] != "rk" && keyParts[0] != "sk" {
 		return false
 	}
 


### PR DESCRIPTION
Allow requests to be made to stripe-mock with the restricted access key
prefix (`rk_`) as well as the standard secret key prefix (`sk_`).

Fixes #199.

r? @ob-stripe
cc @stripe/api-libraries