### PR TITLE
Add /preview endpoint for CreditNote

### DIFF
--- a/server.go
+++ b/server.go
@@ -524,6 +524,7 @@ var hasPrimaryIDSuffixes = [...]string{
 	"/finalize",
 	"/mark_uncollectible",
 	"/pay",
+	"/preview",
 	"/refund",
 	"/reject",
 	"/release",


### PR DESCRIPTION
Previous commit didn't add this file properly.

r? @brandur-stripe 
cc @stripe/api-libraries 