### PR TITLE
Add `-http-addr` and `-https-addr` options to listen on alternate IPs

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -307,7 +307,7 @@ func TestCheckConflictingOptions(t *testing.T) {
 		options.httpPort = 12111
 
 		err := options.checkConflictingOptions()
-		assert.Equal(t, fmt.Errorf("Please don't specify -http when using -http-port or -http-unix"), err)
+		assert.Equal(t, fmt.Errorf("Please don't specify -http when using -http-addr, -http-port, or -http-unix"), err)
 	}
 
 	{
@@ -316,7 +316,7 @@ func TestCheckConflictingOptions(t *testing.T) {
 		options.httpUnixSocket = "/tmp/stripe-mock.sock"
 
 		err := options.checkConflictingOptions()
-		assert.Equal(t, fmt.Errorf("Please don't specify -http when using -http-port or -http-unix"), err)
+		assert.Equal(t, fmt.Errorf("Please don't specify -http when using -http-addr, -http-port, or -http-unix"), err)
 	}
 
 	{
@@ -325,7 +325,7 @@ func TestCheckConflictingOptions(t *testing.T) {
 		options.httpPort = 12111
 
 		err := options.checkConflictingOptions()
-		assert.Equal(t, fmt.Errorf("Please don't specify -port or -unix when using -http-port or -http-unix"), err)
+		assert.Equal(t, fmt.Errorf("Please don't specify -port or -unix when using -http-addr, -http-port, or -http-unix"), err)
 	}
 
 	{
@@ -334,7 +334,16 @@ func TestCheckConflictingOptions(t *testing.T) {
 		options.httpUnixSocket = "/tmp/stripe-mock.sock"
 
 		err := options.checkConflictingOptions()
-		assert.Equal(t, fmt.Errorf("Please don't specify -port or -unix when using -http-port or -http-unix"), err)
+		assert.Equal(t, fmt.Errorf("Please don't specify -port or -unix when using -http-addr, -http-port, or -http-unix"), err)
+	}
+
+	{
+		options := getDefaultOptions()
+		options.httpAddr = "127.0.0.1:12111"
+		options.httpUnixSocket = "/tmp/stripe-mock.sock"
+
+		err := options.checkConflictingOptions()
+		assert.Equal(t, fmt.Errorf("Please specify only one of -http-addr, -http-port, or -http-unix"), err)
 	}
 
 	{
@@ -343,7 +352,7 @@ func TestCheckConflictingOptions(t *testing.T) {
 		options.httpUnixSocket = "/tmp/stripe-mock.sock"
 
 		err := options.checkConflictingOptions()
-		assert.Equal(t, fmt.Errorf("Please specify only one of -http-port or -http-unix"), err)
+		assert.Equal(t, fmt.Errorf("Please specify only one of -http-addr, -http-port, or -http-unix"), err)
 	}
 
 	//
@@ -356,7 +365,7 @@ func TestCheckConflictingOptions(t *testing.T) {
 		options.httpsPort = 12111
 
 		err := options.checkConflictingOptions()
-		assert.Equal(t, fmt.Errorf("Please don't specify -https when using -https-port or -https-unix"), err)
+		assert.Equal(t, fmt.Errorf("Please don't specify -https when using -https-addr, -https-port, or -https-unix"), err)
 	}
 
 	{
@@ -365,7 +374,7 @@ func TestCheckConflictingOptions(t *testing.T) {
 		options.httpsUnixSocket = "/tmp/stripe-mock.sock"
 
 		err := options.checkConflictingOptions()
-		assert.Equal(t, fmt.Errorf("Please don't specify -https when using -https-port or -https-unix"), err)
+		assert.Equal(t, fmt.Errorf("Please don't specify -https when using -https-addr, -https-port, or -https-unix"), err)
 	}
 
 	{
@@ -374,7 +383,7 @@ func TestCheckConflictingOptions(t *testing.T) {
 		options.httpsPort = 12111
 
 		err := options.checkConflictingOptions()
-		assert.Equal(t, fmt.Errorf("Please don't specify -port or -unix when using -https-port or -https-unix"), err)
+		assert.Equal(t, fmt.Errorf("Please don't specify -port or -unix when using -https-addr, -https-port, or -https-unix"), err)
 	}
 
 	{
@@ -383,7 +392,16 @@ func TestCheckConflictingOptions(t *testing.T) {
 		options.httpsUnixSocket = "/tmp/stripe-mock.sock"
 
 		err := options.checkConflictingOptions()
-		assert.Equal(t, fmt.Errorf("Please don't specify -port or -unix when using -https-port or -https-unix"), err)
+		assert.Equal(t, fmt.Errorf("Please don't specify -port or -unix when using -https-addr, -https-port, or -https-unix"), err)
+	}
+
+	{
+		options := getDefaultOptions()
+		options.httpsAddr = "127.0.0.1:12111"
+		options.httpsUnixSocket = "/tmp/stripe-mock.sock"
+
+		err := options.checkConflictingOptions()
+		assert.Equal(t, fmt.Errorf("Please specify only one of -https-addr, -https-port, or -https-unix"), err)
 	}
 
 	{
@@ -392,7 +410,7 @@ func TestCheckConflictingOptions(t *testing.T) {
 		options.httpsUnixSocket = "/tmp/stripe-mock.sock"
 
 		err := options.checkConflictingOptions()
-		assert.Equal(t, fmt.Errorf("Please specify only one of -https-port or -https-unix"), err)
+		assert.Equal(t, fmt.Errorf("Please specify only one of -https-addr, -https-port, or -https-unix"), err)
 	}
 }
 
@@ -400,7 +418,18 @@ func TestCheckConflictingOptions(t *testing.T) {
 const freePort = 0
 
 func TestOptionsGetHTTPListener(t *testing.T) {
-	// Gets a listener when explicitly requested.
+	// Gets a listener when explicitly requested with `-http-addr`.
+	{
+		options := &options{
+			httpAddr: fmt.Sprintf(":%v", freePort),
+		}
+		listener, err := options.getHTTPListener()
+		assert.NoError(t, err)
+		assert.NotNil(t, listener)
+		listener.Close()
+	}
+
+	// Gets a listener when explicitly requested with `-http-port`.
 	{
 		options := &options{
 			httpPort: freePort,
@@ -435,7 +464,18 @@ func TestOptionsGetHTTPListener(t *testing.T) {
 }
 
 func TestOptionsGetNonSecureHTTPSListener(t *testing.T) {
-	// Gets a listener when explicitly requested.
+	// Gets a listener when explicitly requested with `-https-addr`.
+	{
+		options := &options{
+			httpsAddr: fmt.Sprintf(":%v", freePort),
+		}
+		listener, err := options.getNonSecureHTTPSListener()
+		assert.NoError(t, err)
+		assert.NotNil(t, listener)
+		listener.Close()
+	}
+
+	// Gets a listener when explicitly requested with `-https-port`.
 	{
 		options := &options{
 			httpsPort: freePort,


### PR DESCRIPTION
Adds two new command line options that allow users to specify which IPs
they'd like stripe-mock to listen on.

Currently, only `-http-port` and `-https-port` are supported, which pass
an empty string to Go's `Listen` function, which causes stripe-mock to
listen on every available unicast and anycast address on the system [1].
This is fine for most users, but some want a little more control.

The glut of options available for binding to addresses is starting to
get a little out of control, so I've added a comment to the effect that
we're keeping existing options for compatibility, but that we should
consider deprecating `-http-port`, `-https-port`, `-port`, and `-unix`
to simplify the equation somewhat. Maybe at the same time we should
switch to Unix style flags too. (And maybe this will happen if/when
stripe-mock gets merged into the Stripe CLI.)

I've also made a few minor tweaks to the help strings for various
options to try and normalize conventions somewhat.

r? @ob-stripe Sorry, hope you don't mind me assigning this to you.
cc @stripe/api-libraries

Fixes #203.

---

[1] https://godoc.org/net#Listen