### PR TITLE
Adding convenience commands to Makefile for building and running docker image locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+GIT_COMMITSHA = $(shell git rev-parse HEAD)
+IMAGE_NAME = "stripemock/stripe-mock"
+
 all: test vet lint check-gofmt
 
 check-gofmt:
@@ -14,14 +17,10 @@ test:
 vet:
 	go vet ./...
 
-# Docker commands
-.PHONY: docker_build docket_run
-
-GIT_COMMITSHA = $(shell git rev-parse HEAD)
-IMAGE_NAME = "stripemock/stripe-mock"
-
-docker_build:
+docker-build:
 	docker build -t "$(IMAGE_NAME):latest" -t "$(IMAGE_NAME):$(GIT_COMMITSHA)" .
+.PHONY: docker-build 
 
-docker_run:
+docker-run:
 	docker run --rm -it -p 12111-12112:12111-12112 "$(IMAGE_NAME):latest"
+.PHONY: docket-run

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,15 @@ test:
 
 vet:
 	go vet ./...
+
+# Docker commands
+.PHONY: docker_build docket_run
+
+GIT_COMMITSHA = $(shell git rev-parse HEAD)
+IMAGE_NAME = "stripemock/stripe-mock"
+
+docker_build:
+	docker build -t "$(IMAGE_NAME):latest" -t "$(IMAGE_NAME):$(GIT_COMMITSHA)" .
+
+docker_run:
+	docker run --rm -it -p 12111-12112:12111-12112 "$(IMAGE_NAME):latest"

--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,4 @@ docker-build:
 
 docker-run:
 	docker run --rm -it -p 12111-12112:12111-12112 "$(IMAGE_NAME):latest"
-.PHONY: docket-run
+.PHONY: docker-run


### PR DESCRIPTION
Adding 2 commands to the Makefile:
- docker_build: runs the appropriate `docker build` command and tags the resulting image with the current commit hash as well as updating the `latest` tag
- docker_run: runs the appropriate `docker run` command with the default ports configured

If this PR is unnecessary, please feel free to close it. =)