### PR TITLE
Rebuild data replacement strategy to use input from OpenAPI schema

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -141,7 +141,11 @@ func (g *DataGenerator) Generate(params *GenerateParams) (interface{}, error) {
 	// simulate a more realistic create or update operation.
 	if params.RequestMethod == http.MethodPost {
 		if mapData, ok := data.(map[string]interface{}); ok {
-			mapData = datareplacer.ReplaceData(params.RequestData, mapData)
+			replacer := datareplacer.DataReplacer{
+				Definitions: g.definitions,
+				Schema:      params.Schema,
+			}
+			mapData = replacer.ReplaceData(params.RequestData, mapData)
 		}
 	}
 

--- a/generator/datareplacer/datareplacer_test.go
+++ b/generator/datareplacer/datareplacer_test.go
@@ -4,132 +4,370 @@ import (
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-mock/spec"
 )
 
 //
 // Tests
 //
 
-func TestReplaceData_Basic(t *testing.T) {
-	responseData := map[string]interface{}{
-		"foo": "response-value",
+func TestReplaceData_AnyOf(t *testing.T) {
+	replacer := DataReplacer{Schema: &spec.Schema{
+		Properties: map[string]*spec.Schema{
+			"foo": {
+				AnyOf: []*spec.Schema{
+					{
+						Type: spec.TypeString,
+					},
+				},
+			},
+		},
+	}}
+
+	// Incoming matching value (string, which is part of `AnyOf`)
+	{
+		responseData := map[string]interface{}{
+			"foo": "response",
+		}
+
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": "request",
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"foo": "request",
+		}, responseData)
 	}
 
-	ReplaceData(map[string]interface{}{
-		"foo": "request-value",
-	}, responseData)
+	// Incoming non-matching value
+	{
+		responseData := map[string]interface{}{
+			"foo": "response",
+		}
 
-	assert.Equal(t, map[string]interface{}{
-		"foo": "request-value",
-	}, responseData)
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": 123,
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"foo": "response",
+		}, responseData)
+	}
 }
 
 func TestReplaceData_Array(t *testing.T) {
-	// We try to replace arrays wholesale.
+	replacer := DataReplacer{Schema: &spec.Schema{
+		Properties: map[string]*spec.Schema{
+			"foo": {
+				Items: &spec.Schema{
+					Type: spec.TypeString,
+				},
+				Type: spec.TypeArray,
+			},
+		},
+	}}
+
+	// Incoming matching array
 	{
 		responseData := map[string]interface{}{
-			"arr": []interface{}{
-				"response-value",
-			},
+			"foo": []interface{}{"response"},
 		}
 
-		ReplaceData(map[string]interface{}{
-			"arr": []interface{}{
-				"request-value",
-			},
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": []interface{}{"request"},
 		}, responseData)
 
 		assert.Equal(t, map[string]interface{}{
-			"arr": []interface{}{
-				"request-value",
-			},
+			"foo": []interface{}{"request"},
 		}, responseData)
 	}
 
-	// But don't replace them if the types of their elements don't match.
+	// Incoming non-array
 	{
 		responseData := map[string]interface{}{
-			"arr": []interface{}{
-				"response-value",
-			},
+			"foo": []interface{}{"response"},
 		}
 
-		ReplaceData(map[string]interface{}{
-			"arr": []interface{}{
-				7,
-			},
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": "hello",
 		}, responseData)
 
 		assert.Equal(t, map[string]interface{}{
-			"arr": []interface{}{
-				interface{}("response-value"),
-			},
+			"foo": []interface{}{"response"},
 		}, responseData)
 	}
 
-	// Or if we don't have enough elements in either array to determine whether
-	// they're supposed to the same type.
+	// Incoming array, but wrong element type
 	{
 		responseData := map[string]interface{}{
-			"arr": []interface{}{},
+			"foo": []interface{}{"response"},
 		}
 
-		ReplaceData(map[string]interface{}{
-			"arr": []interface{}{
-				"request-value",
-			},
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": []interface{}{123},
 		}, responseData)
 
 		assert.Equal(t, map[string]interface{}{
-			"arr": []interface{}{},
+			"foo": []interface{}{"response"},
+		}, responseData)
+	}
+
+	// Incoming empty array is allowed to replace
+	{
+		responseData := map[string]interface{}{
+			"foo": []interface{}{"response"},
+		}
+
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": []interface{}{},
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"foo": []interface{}{},
 		}, responseData)
 	}
 }
 
-func TestReplaceData_Recursive(t *testing.T) {
-	responseData := map[string]interface{}{
-		"map": map[string]interface{}{
-			"nested": "response-value",
+func TestReplaceData_Boolean(t *testing.T) {
+	replacer := DataReplacer{Schema: &spec.Schema{
+		Properties: map[string]*spec.Schema{
+			"foo": {
+				Type: spec.TypeBoolean,
+			},
+		},
+	}}
+
+	// Incoming boolean
+	{
+		responseData := map[string]interface{}{
+			"foo": false,
+		}
+
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": true,
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"foo": true,
+		}, responseData)
+	}
+
+	// Incoming non-boolean
+	{
+		responseData := map[string]interface{}{
+			"foo": false,
+		}
+
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": "hello",
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"foo": false,
+		}, responseData)
+	}
+}
+
+func TestReplaceData_Integer(t *testing.T) {
+	replacer := DataReplacer{Schema: &spec.Schema{
+		Properties: map[string]*spec.Schema{
+			"foo": {
+				Type: spec.TypeInteger,
+			},
+		},
+	}}
+
+	// Incoming integer
+	{
+		responseData := map[string]interface{}{
+			"foo": 123,
+		}
+
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": 456,
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"foo": 456,
+		}, responseData)
+	}
+
+	// Incoming non-integer
+	{
+		responseData := map[string]interface{}{
+			"foo": 123,
+		}
+
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": "hello",
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"foo": 123,
+		}, responseData)
+	}
+}
+
+func TestReplaceData_Number(t *testing.T) {
+	replacer := DataReplacer{Schema: &spec.Schema{
+		Properties: map[string]*spec.Schema{
+			"foo": {
+				Type: spec.TypeNumber,
+			},
+		},
+	}}
+
+	// Incoming number
+	{
+		responseData := map[string]interface{}{
+			"foo": 1.23,
+		}
+
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": 4.56,
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"foo": 4.56,
+		}, responseData)
+	}
+
+	// Incoming non-number
+	{
+		responseData := map[string]interface{}{
+			"foo": 1.23,
+		}
+
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": "hello",
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"foo": 1.23,
+		}, responseData)
+	}
+}
+
+func TestReplaceData_String(t *testing.T) {
+	replacer := DataReplacer{Schema: &spec.Schema{
+		Properties: map[string]*spec.Schema{
+			"foo": {
+				Type: spec.TypeString,
+			},
+		},
+	}}
+
+	// Incoming string
+	{
+		responseData := map[string]interface{}{
+			"foo": "response",
+		}
+
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": "request",
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"foo": "request",
+		}, responseData)
+	}
+
+	// Incoming non-string
+	{
+		responseData := map[string]interface{}{
+			"foo": "response",
+		}
+
+		replacer.ReplaceData(map[string]interface{}{
+			"foo": 123,
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"foo": "response",
+		}, responseData)
+	}
+}
+
+func TestReplaceData_Deferences(t *testing.T) {
+	replacer := DataReplacer{
+		Definitions: map[string]*spec.Schema{
+			"foo_object": {
+				Type: spec.TypeString,
+			},
+		},
+		Schema: &spec.Schema{
+			Properties: map[string]*spec.Schema{
+				"foo": {
+					Ref: "#/definitions/foo_object",
+				},
+			},
 		},
 	}
 
-	ReplaceData(map[string]interface{}{
-		"map": map[string]interface{}{
-			"nested": "request-value",
+	responseData := map[string]interface{}{
+		"bar": "response",
+	}
+
+	replacer.ReplaceData(map[string]interface{}{
+		"bar": "request",
+	}, responseData)
+
+	assert.Equal(t, map[string]interface{}{
+		"bar": "response",
+	}, responseData)
+}
+
+func TestReplaceData_Nested(t *testing.T) {
+	replacer := DataReplacer{Schema: &spec.Schema{
+		Properties: map[string]*spec.Schema{
+			"foo": {
+				Properties: map[string]*spec.Schema{
+					"bar": {
+						Type: spec.TypeString,
+					},
+				},
+			},
+		},
+	}}
+
+	responseData := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"bar": "response",
+		},
+	}
+
+	replacer.ReplaceData(map[string]interface{}{
+		"foo": map[string]interface{}{
+			"bar": "request",
 		},
 	}, responseData)
 
 	assert.Equal(t, map[string]interface{}{
-		"map": map[string]interface{}{
-			"nested": "request-value",
+		"foo": map[string]interface{}{
+			"bar": "request",
 		},
 	}, responseData)
 }
 
-func TestReplaceData_DontReplaceOnDifferentFields(t *testing.T) {
+// Nothing gets replaced if we don't find the field in the schema.
+func TestReplaceData_NotInSchema(t *testing.T) {
+	replacer := DataReplacer{Schema: &spec.Schema{
+		Properties: map[string]*spec.Schema{
+			"foo": {
+				Type: spec.TypeString,
+			},
+		},
+	}}
+
 	responseData := map[string]interface{}{
-		"other": "other-value",
+		"bar": "response",
 	}
 
-	ReplaceData(map[string]interface{}{
-		"foo": "request-value",
+	replacer.ReplaceData(map[string]interface{}{
+		"bar": "request",
 	}, responseData)
 
 	assert.Equal(t, map[string]interface{}{
-		"other": "other-value",
-	}, responseData)
-}
-
-func TestReplaceData_DontReplaceOnDifferentTypes(t *testing.T) {
-	responseData := map[string]interface{}{
-		"foo": "response-value",
-	}
-
-	ReplaceData(map[string]interface{}{
-		"foo": 7,
-	}, responseData)
-
-	assert.Equal(t, map[string]interface{}{
-		"foo": "response-value",
+		"bar": "response",
 	}, responseData)
 }

--- a/generator/datareplacer/datareplacer_test.go
+++ b/generator/datareplacer/datareplacer_test.go
@@ -24,25 +24,66 @@ func TestReplaceData_Basic(t *testing.T) {
 	}, responseData)
 }
 
-// Arrays are currently just replaced wholesale.
 func TestReplaceData_Array(t *testing.T) {
-	responseData := map[string]interface{}{
-		"arr": []string{
-			"response-value",
-		},
+	// We try to replace arrays wholesale.
+	{
+		responseData := map[string]interface{}{
+			"arr": []interface{}{
+				"response-value",
+			},
+		}
+
+		ReplaceData(map[string]interface{}{
+			"arr": []interface{}{
+				"request-value",
+			},
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"arr": []interface{}{
+				"request-value",
+			},
+		}, responseData)
 	}
 
-	ReplaceData(map[string]interface{}{
-		"arr": []string{
-			"request-value",
-		},
-	}, responseData)
+	// But don't replace them if the types of their elements don't match.
+	{
+		responseData := map[string]interface{}{
+			"arr": []interface{}{
+				"response-value",
+			},
+		}
 
-	assert.Equal(t, map[string]interface{}{
-		"arr": []string{
-			"request-value",
-		},
-	}, responseData)
+		ReplaceData(map[string]interface{}{
+			"arr": []interface{}{
+				7,
+			},
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"arr": []interface{}{
+				interface{}("response-value"),
+			},
+		}, responseData)
+	}
+
+	// Or if we don't have enough elements in either array to determine whether
+	// they're supposed to the same type.
+	{
+		responseData := map[string]interface{}{
+			"arr": []interface{}{},
+		}
+
+		ReplaceData(map[string]interface{}{
+			"arr": []interface{}{
+				"request-value",
+			},
+		}, responseData)
+
+		assert.Equal(t, map[string]interface{}{
+			"arr": []interface{}{},
+		}, responseData)
+	}
 }
 
 func TestReplaceData_Recursive(t *testing.T) {


### PR DESCRIPTION
Previously, the data replacer worked by taking input request and output 
response data, and replacing values if the types matched up. This generally
worked, but would result in some inappropriate replacements for more
complex data types like arrays, as seen in [1].

In this patch we upgrade the replacement strategy so that we perform 
replacements if the type of incoming request data matches what we expected
in the response based on the OpenAPI schema. This allows us, for example,
to not only check that a type is an array, but also what sort of elements
that array is supposed to contain, even if the value from our fixtures is
an empty array (which is often the case).

Fixes #210.

r? @ob-stripe
cc @stripe/api-libraries

---

[1] https://github.com/stripe/stripe-mock/issues/210