### PR TITLE
Add support for new /submit endpoint to stripe-mock

### DIFF
--- a/server.go
+++ b/server.go
@@ -529,6 +529,7 @@ var hasPrimaryIDSuffixes = [...]string{
 	"/reject",
 	"/release",
 	"/send",
+	"/submit",
 	"/verify",
 	"/void",
 }


### PR DESCRIPTION
Add support for `/submit` as a custom endpoint so that stripe-mock properly handles extracting the id from the URL. This endpoint is specific to the Issuing Dispute API which is going to GA on Thursday

r? @brandur-stripe @richardm-stripe 
cc @stripe/api-libraries 