### PR TITLE
Include /accept in URL paths which have a primary ID.

### DIFF
--- a/server.go
+++ b/server.go
@@ -513,6 +513,7 @@ var hasPrimaryIDSuffixes = [...]string{
 
 	// These are resource "actions". They don't take the standard form, but we
 	// can expect an object's primary ID to live right before them in a path.
+	"/accept",
 	"/approve",
 	"/attach",
 	"/capture",


### PR DESCRIPTION
Updates the list of suffixes for API methods with primary IDs to include `/accept`. This is in preparation of Quotes, which will have `/v1/quotes/qt_<id>/accept`. This ensure stripe-mock extracts and returns the primary ID for these calls.