### PR TITLE
goreleaser: fix "staticcheck" vendoring

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -4,7 +4,7 @@ before:
   hooks:
     - go get -u honnef.co/go/tools/cmd/staticcheck@latest
     - go install github.com/go-bindata/go-bindata/...@latest
-    - go generate
+    - go generate -mod=readonly
 
 builds:
   - binary: stripe-mock


### PR DESCRIPTION
## Summary
Releases are broken: https://github.com/stripe/stripe-mock/actions/runs/1322583063

It's complaining about "inconsistent vendoring". This PR adds one of the flags that `go generate` recommends to squelch the error.

For a little context, Golang doesn't have a great story for "devDependencies" -- i.e. packages you depend on that you only use for your build/release process, but don't want to add to your go.mod because you don't want to introduce indirect dependencies to the packages that depend on your package. What we do to handle this is just to manually install the dependencies before running `go generate` in our goreleaser script:
```yaml
before:
  hooks:
    - go get -u honnef.co/go/tools/cmd/staticcheck@latest
    - go install github.com/go-bindata/go-bindata/...@latest
    - go generate
```
