### PR TITLE
Update GoReleaser version.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.173.2 # Latest version as of 2021-07-16
+          version: v0.183.0 # Latest version as of 2021-10-28
           args: release -f goreleaser.yml --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}


### PR DESCRIPTION
r? @richardm-stripe 
cc @ob-stripe 

Updates the GoReleaser version to [latest](https://goreleaser.com/).

This should remove a warning upon install:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the stripe/stripe-mock tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/stripe/homebrew-stripe-mock/stripe-mock.rb:9
```