### PR TITLE
Remove deprecated binaries property from goreleaser.yml

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -77,8 +77,6 @@ nfpms:
     - rpm
 
 dockers:
-  - binaries:
-    - stripe-mock
-    image_templates:
-    - "stripe/stripe-mock:latest"
-    - "stripe/stripe-mock:{{ .Tag }}"
+  image_templates:
+  - "stripe/stripe-mock:latest"
+  - "stripe/stripe-mock:{{ .Tag }}"


### PR DESCRIPTION
This property was deprecated: https://github.com/goreleaser/goreleaser/pull/2400/files

I'm not exactly sure what the recommended replacement strategy is, but I think just omitting it and moving it to the top level aligns with what the goreleaser docs currently suggest:
Apparently
![image](https://user-images.githubusercontent.com/52928443/139335801-7f1d5631-76ef-4b36-97f0-a76900ffde66.png)

So let's just merge this and see if it works!