### PR TITLE
Add support for Apple Silicon / ARM64

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -17,6 +17,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
 
 snapshot:
   name_template: "{{ .Tag }}-next"


### PR DESCRIPTION
When installing `stripe-mock` on Apple Silicon devices using homebrew, the following error occurs:

```
brew install stripe/stripe-mock/stripe-mock
==> Tapping stripe/stripe-mock
Cloning into '/opt/homebrew/Library/Taps/stripe/homebrew-stripe-mock'...
remote: Enumerating objects: 457, done.
remote: Counting objects: 100% (39/39), done.
remote: Compressing objects: 100% (26/26), done.
remote: Total 457 (delta 12), reused 0 (delta 0), pack-reused 418
Receiving objects: 100% (457/457), 62.71 KiB | 917.00 KiB/s, done.
Resolving deltas: 100% (148/148), done.
Error: Invalid formula: /opt/homebrew/Library/Taps/stripe/homebrew-stripe-mock/stripe-mock.rb
formulae require at least a URL
Error: Cannot tap stripe/stripe-mock: invalid syntax in tap!
```

This change attempts to update the brew formula so that `stripe-mock` can be installed via homebrew on Apple Silicon devices.

Note that I have never used GoReleaser before so I'm not sure how to test that this change solves the issue.

Any guidance would be appreciated.

Hopefully fixes #263