### PR TITLE
Fix docker image name in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ HTTP/2.
 ### Docker
 
 ``` sh
-docker run --rm -it -p 12111-12112:12111-12112 stripemock/stripe-mock:latest
+docker run --rm -it -p 12111-12112:12111-12112 stripe/stripe-mock:latest
 ```
 
 The default Docker `ENTRYPOINT` listens on port `12111` for HTTP and `12112`


### PR DESCRIPTION
r? @kamil-stripe @richardm-stripe 

## Summary

Updates the README to use the correct docker image name.

## Motivation

Fixes https://github.com/stripe/stripe-mock/issues/299