### PR TITLE
fix: Set Content-Type on responses.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -301,8 +301,10 @@ func (s *StubServer) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	var responseContent spec.MediaType
 
 	if jsonResponseContent, ok := response.Content["application/json"]; ok && jsonResponseContent.Schema != nil {
+		w.Header().Set("Content-Type", "application/json")
 		responseContent = jsonResponseContent
 	} else if pdfResponseContent, ok := response.Content["application/pdf"]; ok && pdfResponseContent.Schema != nil {
+		w.Header().Set("Content-Type", "application/pdf")
 		responseContent = pdfResponseContent
 	} else {
 		fmt.Printf("Couldn't find application/json or application/pdf in response\n")
@@ -894,6 +896,11 @@ func writeResponse(w http.ResponseWriter, r *http.Request, start time.Time, stat
 
 	var encodedData []byte
 	var err error
+
+	// If no special Content-Type has been set, then we default to JSON.
+	if w.Header().Get("Content-Type") == "" {
+		w.Header().Set("Content-Type", "application/json")
+	}
 
 	if dataString, ok := data.(string); ok {
 		encodedData = []byte(dataString)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -470,12 +470,14 @@ func TestStubServer_SetsSpecialHeaders(t *testing.T) {
 	resp, _ := sendRequest(t, "POST", "/", "", nil, nil)
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	assert.Equal(t, Version, resp.Header.Get("Stripe-Mock-Version"))
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 	_, ok := resp.Header["Request-Id"]
 	assert.False(t, ok)
 
 	resp, _ = sendRequest(t, "POST", "/", "", getDefaultHeaders(), nil)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	assert.Equal(t, Version, resp.Header.Get("Stripe-Mock-Version"))
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 	assert.Equal(t, "req_123", resp.Header.Get("Request-Id"))
 }
 
@@ -655,10 +657,18 @@ func TestStubServer_RoutesRequest(t *testing.T) {
 	}
 }
 
+func TestStubServer_JSONResponse(t *testing.T) {
+	resp, _ := sendRequest(t, "GET", "/v1/charges",
+		"", getDefaultHeaders(), nil)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+}
+
 func TestStubServer_BinaryResponse(t *testing.T) {
 	resp, body := sendRequest(t, "GET", "/v1/quotes/qt_123/pdf",
 		"", getDefaultHeaders(), nil)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/pdf", resp.Header.Get("Content-Type"))
 	assert.Equal(t, "Stripe binary response", string(body[:]))
 }
 


### PR DESCRIPTION
## Summary

Sets an appropriate `Content-Type` response header, mirroring our production API. Currently stripe-mock always returns JSON or PDF (it doesn't support the Files API).

## Motivation

Fixes https://github.com/stripe/stripe-mock/issues/312