### PR TITLE
Attempt to use the standard github token with GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,4 @@ jobs:
           version: v0.183.0 # Latest version as of 2021-10-28
           args: release -f goreleaser.yml --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
CLI seems to be doing it: https://github.com/stripe/stripe-cli/blob/master/.github/workflows/release.yml#L73