### PR TITLE
Checkout the repository before tagging

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,6 +12,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Code checkout
+        uses: actions/checkout@v2
       - name: Set the commit SHA
         id: sha
         run: echo "::set-output name=commitSha::$(if [ -z "$SHA" ]; then echo $GITHUB_SHA; else echo $SHA; fi)"


### PR DESCRIPTION
Running `git` requires the repo to be checked out.