### PR TITLE
Fetch history when cloning the repo for tagging

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set the commit SHA
         id: sha
         run: echo "::set-output name=commitSha::$(if [ -z "$SHA" ]; then echo $GITHUB_SHA; else echo $SHA; fi)"


### PR DESCRIPTION
The default `fetch-depth: 1` doesn't bring down all the tags. We need existing tags to determine the new tag.