### PR TITLE
Support objects inside additionalProperties

### DIFF
--- a/param/coercer/coercer_test.go
+++ b/param/coercer/coercer_test.go
@@ -50,6 +50,34 @@ func TestCoerceParams_AnyOfCoercion(t *testing.T) {
 		assert.Equal(t, 123, data["object_or_int_key"].(map[string]interface{})["intkey"])
 	}
 
+	// `anyOf` with object type in additional properties
+	{
+		schema := &spec.Schema{Properties: map[string]*spec.Schema{
+			"map": {
+				AnyOf: []*spec.Schema{
+					{AdditionalProperties: &spec.Schema{
+						Properties: map[string]*spec.Schema{
+							"intkey": {Type: integerType},
+						},
+					}},
+					{Type: objectType},
+				},
+			},
+		}}
+		data := map[string]interface{}{
+			"map": map[string]interface{}{
+				"item": map[string]interface{}{
+					"intkey": "123",
+				},
+			},
+		}
+
+		err := CoerceParams(schema, data)
+		assert.NoError(t, err)
+		item := data["map"].(map[string]interface{})["item"]
+		assert.Equal(t, 123, item.(map[string]interface{})["intkey"])
+	}
+
 	// `anyOf` with array of mixed types
 	{
 		schema := &spec.Schema{Properties: map[string]*spec.Schema{

--- a/spec/query.go
+++ b/spec/query.go
@@ -5,7 +5,7 @@ package spec
 // query parameters in a different, non-JSON schema part of an operation.
 func BuildQuerySchema(operation *Operation) *Schema {
 	schema := &Schema{
-		AdditionalProperties: false,
+		AdditionalProperties: nil,
 		Properties:           make(map[string]*Schema),
 		Required:             make([]string, 0),
 		Type:                 TypeObject,


### PR DESCRIPTION
Currently, stripe-mock only supports strings as values of maps. Maps are represented by the following structure in OpenAPI: 
```yaml
  - additionalProperties:
      properties:
        custom_unit_amount:

```

This PR teaches stripe-mock to deserialize and validate requests that have complex types in map values.

r? @yejia-stripe 