### PR TITLE
Handle ID prefixes with underscores

### DIFF
--- a/server/generator.go
+++ b/server/generator.go
@@ -891,8 +891,13 @@ func maybeGeneratePrimaryID(pathParams *PathParamsMap, data interface{}) *PathPa
 		return pathParams
 	}
 
+	prefix := id
+
+	usInd := strings.LastIndex(id, "_")
 	// Like `sub_sched`.
-	prefix := id[:strings.LastIndex(id, "_")]
+	if usInd != -1 {
+		prefix = id[:usInd]
+	}
 
 	newID := randomID(prefix)
 

--- a/server/generator.go
+++ b/server/generator.go
@@ -891,11 +891,8 @@ func maybeGeneratePrimaryID(pathParams *PathParamsMap, data interface{}) *PathPa
 		return pathParams
 	}
 
-	// Splits something like `ch_123` into `["ch", "123"]`.
-	idParts := strings.Split(id, "_")
-
-	// Like `ch`.
-	prefix := idParts[0]
+	// Like `sub_sched`.
+	prefix := id[:strings.LastIndex(id, "_")]
 
 	newID := randomID(prefix)
 
@@ -928,7 +925,7 @@ func propertyNames(schema *spec.Schema) string {
 //
 // As with the real Stripe API, the general format looks like:
 //
-//     <prefix>_<time_part><random_part>
+//	<prefix>_<time_part><random_part>
 //
 // The prefix helps identify the type of object. For example, charges have a
 // `ch` prefix.

--- a/server/generator_test.go
+++ b/server/generator_test.go
@@ -260,6 +260,31 @@ func TestGenerateResponseData(t *testing.T) {
 			data.(map[string]interface{})["id"])
 	}
 
+	// generated primary ID (double prefix)
+	{
+		generator := DataGenerator{testSpec.Components.Schemas, &spec.Fixtures{
+			Resources: map[spec.ResourceID]interface{}{
+				spec.ResourceID("charge"): map[string]interface{}{
+					"id": "ch_sub_123",
+				},
+			},
+		}, verbose}
+		data, err := generator.Generate(&GenerateParams{
+			PathParams: &PathParamsMap{},
+			Schema:     &spec.Schema{Ref: "#/components/schemas/charge"},
+		})
+		assert.Nil(t, err)
+
+		// Should not be equal to our fixture's ID because it's generated.
+		assert.NotEqual(t, "ch_sub_123",
+			data.(map[string]interface{})["id"])
+
+		// However, the fixture's ID's prefix will have been used to generate
+		// the new ID, so it should share a prefix.
+		assert.Regexp(t, regexp.MustCompile("^ch_sub_"),
+			data.(map[string]interface{})["id"])
+	}
+
 	// generated primary ID (nil PathParamsMap)
 	{
 		generator := DataGenerator{testSpec.Components.Schemas, &spec.Fixtures{


### PR DESCRIPTION
We were using only the first segment of fixture ID for random ID generation. `sub_sched_123` was turned into `sub_123456` in the process.

