### PR TITLE
Edit the README to reflect narrower scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ stripe-mock is a mock HTTP server based on the real Stripe API. It accepts the
 same requests and parameters that the Stripe API accepts, and rejects requests
 whose parameters are not recognized or have incorrect types. Its responses
 resemble the responses of the real Stripe API in terms of data type; however,
-stripe-mock does not attempt to reproduce the _behavior_ of the real Stripe API
-at all. It cannot reject all invalid requests, and its responses are completely
+stripe-mock **does not attempt to reproduce the _behavior_ of the real Stripe API
+at all**. It cannot reject all invalid requests, and its responses are completely
 hardcoded. They will have a correct type, but they will not necessarily be
 realistic Stripe responses.
 

--- a/README.md
+++ b/README.md
@@ -1,75 +1,95 @@
 # stripe-mock [![Build Status](https://travis-ci.org/stripe/stripe-mock.svg?branch=master)](https://travis-ci.org/stripe/stripe-mock)
 
-stripe-mock is a mock HTTP server that responds like the real Stripe API. It
-can be used instead of Stripe's test mode to make test suites integrating with
-Stripe faster and less brittle. It's powered by [the Stripe OpenAPI
-specification][openapi], which is generated from within Stripe's API.
+stripe-mock is a mock HTTP server based on the real Stripe API. It accepts the
+same requests and parameters that the Stripe API accepts, and rejects requests
+whose parameters are not recognized or have incorrect types. Its responses
+resemble the responses of the real Stripe API in terms of data type; however,
+stripe-mock does not attempt to reproduce the _behavior_ of the real Stripe API
+at all. It cannot reject all invalid requests, and its responses are completely
+hardcoded. They will have a correct type, but they will not necessarily be
+realistic Stripe responses.
 
-## Current state of development
+stripe-mock is meant for basic sanity checks. We use it in the test suites of
+our server-side SDKs, like [stripe-ruby](https://github.com/stripe/stripe-ruby),
+[stripe-go](https://github.com/stripe/stripe-go), etc, to help validate that the
+SDK hits the right URL and sends the right parameters. If you have more
+sophisticated testing needs, you shouldn't use stripe-mock. Always test changes
+to your Stripe integration against
+[testmode](https://stripe.com/docs/keys#test-live-modes). For regression test
+suites, you should define your own mocks, or use a playback testing tool such as
+the [VCR gem](https://github.com/vcr/vcr).
 
-stripe-mock is able to generate an approximately correct API response for any
-endpoint, but the logic for doing so is still quite naive. It supports the
-following features:
+While stripe-mock is naïve, it is powered by
+[the Stripe OpenAPI specification][openapi] and is therefore kept up-to-date
+with the latest methods, resources, and fields.
 
-* It has a catalog of every API URL and their signatures. It responds on URLs
+## Features and limitations
+
+stripe-mock supports the following features:
+
+- It has a catalog of every API URL and their signatures. It responds to URLs
   that exist with a resource that it returns and 404s on URLs that don't exist.
-* JSON Schema is used to check the validity of the parameters of incoming
+- JSON Schema is used to check the validity of the parameters of incoming
   requests. Validation is comprehensive, but far from exhaustive, so don't
   expect the full barrage of checks of the live API.
-* Responses are generated based off resource fixtures. They're also generated
-  from within Stripe's API, and similar to the sample data available in
-  Stripe's [API reference][apiref].
-* It reflects the values of valid input parameters into responses where the
+- Responses are generated based off resource fixtures. They're also generated
+  from within Stripe's API, and similar to the sample data available in Stripe's
+  [API reference][apiref]. **They are hardcoded**, and will not necessarily
+  represent realistic responses based on the parameters you input into the
+  request.
+- It reflects the values of valid input parameters into responses where the
   naming and type are the same. So if a charge is created with `amount=123`, a
   charge will be returned with `"amount": 123`.
-* It will respond over HTTP or over HTTPS. HTTP/2 over HTTPS is available if
-  the client supports it.
+- It will respond over HTTP or over HTTPS. HTTP/2 over HTTPS is available if the
+  client supports it.
 
 Limitations:
 
-* It's currently stateless. Data created with `POST` calls won't be stored so
-  that the same information is available later.
-* For polymorphic endpoints (say one that returns either a card or a bank
+- stripe-mock is stateless. Data you send on a `POST` request will be validated,
+  but it will be completely ignored beyond that. It will not be reflected on the
+  response or on any future request -- unlike the real Stripe API, which stores
+  the information you send it.
+- For polymorphic endpoints (say one that returns either a card or a bank
   account), only a single resource type is ever returned. There's no way to
   specify which one that is.
-* It's locked to the latest version of Stripe's API and doesn't support old
+- It's locked to the latest version of Stripe's API and doesn't support old
   versions.
-* [Testing for specific responses and errors](https://stripe.com/docs/testing#cards-responses)
-  is currently not supported. It will return a success response instead of
-  the desired error response.
+- [Testing for specific responses and errors](https://stripe.com/docs/testing#cards-responses)
+  is currently not supported. It will return a success response instead of the
+  desired error response.
 
 ## Future plans
 
-The next important feature that we're aiming to provide is statefulness. The
-idea would be that resources created during a session would be stored for that
-session's duration and could be subsequently retrieved, updated, and deleted.
-This would allow more comprehensive integration tests to run successfully
-against stripe-mock.
-
-We'll continue to aim to improve the quality of stripe-mock's responses, but it
-will never be on perfect parity with the live API. We think the ideal test
-suite for an integration would involve running most of the suite against
-stripe-mock, and then to have a few smoke tests run critical flows against the
-more accurate (but also slower) Stripe API in test mode.
+The scope we envision for stripe-mock has significantly narrowed since 2017 when
+we first released it. Back in 2017, our vision was for stripe-mock was to return
+responses that were _realistic_ as well as just having the expected types. This
+has changed. We are currently **not** planning to add statefulness or more
+sophisticated testing features to stripe-mock. stripe-mock will remain a tool
+for basic sanity checks. If you have more sophisticated needs, you should define
+your own mocks, use a playback testing tool like the
+[VCR gem](https://github.com/vcr/vcr), or find a community library you trust. Be
+careful, though. Always test changes to your Stripe integration against
+testmode. Mock implementations of Stripe can never behave exactly at the Stripe
+API does, and might differ in nuanced (and potentially dangerous) ways.
 
 ## Usage
 
 If you have Go installed, you can install the basic binary with:
 
-``` sh
+```sh
 go get -u github.com/stripe/stripe-mock
 ```
 
 With no arguments, stripe-mock will listen with HTTP on its default port of
 `12111` and HTTPS on `12112`:
 
-``` sh
+```sh
 stripe-mock
 ```
 
 Ports can be specified explicitly with:
 
-``` sh
+```sh
 stripe-mock -http-port 12111 -https-port 12112
 ```
 
@@ -78,13 +98,13 @@ one protocol.)
 
 Have stripe-mock select a port automatically by passing `0`:
 
-``` sh
+```sh
 stripe-mock -http-port 0
 ```
 
 It can also listen via Unix socket:
 
-``` sh
+```sh
 stripe-mock -http-unix /tmp/stripe-mock.sock -https-unix /tmp/stripe-mock-secure.sock
 ```
 
@@ -92,7 +112,7 @@ stripe-mock -http-unix /tmp/stripe-mock.sock -https-unix /tmp/stripe-mock-secure
 
 Get it from Homebrew or download it [from the releases page][releases]:
 
-``` sh
+```sh
 brew install stripe/stripe-mock/stripe-mock
 
 # start a stripe-mock service at login
@@ -110,18 +130,18 @@ HTTP/2.
 
 ### Docker
 
-``` sh
+```sh
 docker run --rm -it -p 12111-12112:12111-12112 stripe/stripe-mock:latest
 ```
 
-The default Docker `ENTRYPOINT` listens on port `12111` for HTTP and `12112`
-for HTTPS and HTTP/2.
+The default Docker `ENTRYPOINT` listens on port `12111` for HTTP and `12112` for
+HTTPS and HTTP/2.
 
 ### Sample request
 
 After you've started stripe-mock, you can try a sample request against it:
 
-``` sh
+```sh
 curl -i http://localhost:12111/v1/charges -H "Authorization: Bearer sk_test_123"
 ```
 
@@ -131,28 +151,30 @@ curl -i http://localhost:12111/v1/charges -H "Authorization: Bearer sk_test_123"
 
 Run the test suite:
 
-``` sh
+```sh
 go test ./...
 ```
 
 ### Updating OpenAPI
 
-Update the OpenAPI spec by running `make update-openapi-spec` in the root of the repo.
+Update the OpenAPI spec by running `make update-openapi-spec` in the root of the
+repo.
 
-``` sh
+```sh
 make update-openapi-spec
 ```
 
 ## Dependencies
 
-Dependencies are managed using [go modules][gomod] and require Go 1.11+ with `GO111MODULE=on`.
+Dependencies are managed using [go modules][gomod] and require Go 1.11+ with
+`GO111MODULE=on`.
 
 ## Release
 
-Releases are automatically published by Travis CI using [goreleaser] when a
-new tag is pushed:
+Releases are automatically published by Travis CI using [goreleaser] when a new
+tag is pushed:
 
-``` sh
+```sh
 git pull origin --tags
 git tag v0.1.1
 git push origin --tags


### PR DESCRIPTION
## Notify
cc @stripe/api-libraries 

## Background
We've had several github issues open for years requesting more sophisticated testing features for stripe-mock, like statefulness. This used to be something that we intended to add, but just never prioritized, but in more recent years our thinking about the proper scope of this project has changed internally, and it's time we communicate this to users and set more realistic expectations.

## Summary
This PR changes the README to reflect how we think about this project and it's scope. After it is merged, I plan on updating/closing all our stale issues on this repository so they reflect the current project direction.