### PR TITLE
Revert "Add support for multi-platform Docker images"

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -79,28 +79,5 @@ nfpms:
 
 dockers:
   - image_templates:
-      - "stripe/stripe-mock:{{ .Tag }}-amd64"
-      - "stripe/stripe-mock:latest-amd64"
-    use: buildx
-    goos: linux
-    goarch: amd64
-    build_flag_templates:
-      - "--platform=linux/amd64"
-  - image_templates:
-      - "stripe/stripe-mock:{{ .Tag }}-arm64"
-      - "stripe/stripe-mock:latest-arm64"
-    use: buildx
-    goos: linux
-    goarch: arm64
-    build_flag_templates:
-      - "--platform=linux/arm64"
-
-docker_manifests:
-  - name_template: "stripe/stripe-mock:{{ .Tag }}"
-    image_templates: &image_templates
-      - "stripe/stripe-mock:{{ .Tag }}-amd64"
-      - "stripe/stripe-mock:{{ .Tag }}-arm64"
-  - name_template: "stripe/stripe-mock:latest"
-    image_templates: &image_templates
-      - "stripe/stripe-mock:latest-amd64"
-      - "stripe/stripe-mock:latest-arm64"
+    - "stripe/stripe-mock:latest"
+    - "stripe/stripe-mock:{{ .Tag }}"


### PR DESCRIPTION
Reverts stripe/stripe-mock#380

This causes a [CI error](https://github.com/stripe/stripe-mock/actions/runs/4346863543/jobs/7593453209) during release, reverting to investigate