### PR TITLE
Fix multi arch release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,12 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -79,5 +79,28 @@ nfpms:
 
 dockers:
   - image_templates:
-    - "stripe/stripe-mock:latest"
-    - "stripe/stripe-mock:{{ .Tag }}"
+      - "stripe/stripe-mock:{{ .Tag }}-amd64"
+      - "stripe/stripe-mock:latest-amd64"
+    use: buildx
+    goos: linux
+    goarch: amd64
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "stripe/stripe-mock:{{ .Tag }}-arm64"
+      - "stripe/stripe-mock:latest-arm64"
+    use: buildx
+    goos: linux
+    goarch: arm64
+    build_flag_templates:
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "stripe/stripe-mock:{{ .Tag }}"
+    image_templates: &image_templates
+      - "stripe/stripe-mock:{{ .Tag }}-amd64"
+      - "stripe/stripe-mock:{{ .Tag }}-arm64"
+  - name_template: "stripe/stripe-mock:latest"
+    image_templates: &image_templates
+      - "stripe/stripe-mock:latest-amd64"
+      - "stripe/stripe-mock:latest-arm64"


### PR DESCRIPTION
Noticed #392. In order to build the amd64 image it's necessary to install qemu and buildx.

Validated on my fork: https://github.com/ewdurbin/stripe-mock/actions/runs/4364861761/jobs/7632707111#step:6:102
