### PR TITLE
fix(Docker): Macos docker failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 # -*- mode: dockerfile -*-
 
+FROM golang:alpine as builder
+WORKDIR /app
+COPY . .
+
+RUN go build -mod=vendor -o stripe-mock
+
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
-COPY stripe-mock /bin/stripe-mock
+COPY --from=builder /app/stripe-mock /bin/stripe-mock
 ENTRYPOINT ["/bin/stripe-mock", "-http-port", "12111", "-https-port", "12112"]
 EXPOSE 12111
 EXPOSE 12112

--- a/embedded/openapi/fixtures3.json
+++ b/embedded/openapi/fixtures3.json
@@ -2003,15 +2003,12 @@
       "last_payment_error": null,
       "latest_charge": null,
       "livemode": false,
-      "metadata": {
-        "order_id": "pay_oKIb82AehukmsQcs5YoZ",
-        "txn_id": "merchant_x_pay_oKIb82AehukmsQcs5YoZ",
-        "txn_uuid": "merchant_x_pay_oKIb82AehukmsQcs5YoZ"
-      },
+      "metadata": {},
       "next_action": null,
       "object": "payment_intent",
       "on_behalf_of": null,
       "payment_method": null,
+      "payment_method_options": {},
       "payment_method_types": [
         "card"
       ],

--- a/embedded/openapi/fixtures3.json
+++ b/embedded/openapi/fixtures3.json
@@ -2003,12 +2003,15 @@
       "last_payment_error": null,
       "latest_charge": null,
       "livemode": false,
-      "metadata": {},
+      "metadata": {
+        "order_id": "pay_oKIb82AehukmsQcs5YoZ",
+        "txn_id": "merchant_x_pay_oKIb82AehukmsQcs5YoZ",
+        "txn_uuid": "merchant_x_pay_oKIb82AehukmsQcs5YoZ"
+      },
       "next_action": null,
       "object": "payment_intent",
       "on_behalf_of": null,
       "payment_method": null,
-      "payment_method_options": {},
       "payment_method_types": [
         "card"
       ],


### PR DESCRIPTION
Native binary loaded into docker images doesn't work in case of Mac. Hence changed docker to build and create the docker image.

```
 # stripe-mock > hyperswitch-stripe-mock > make docker-build
docker build -t ""stripe/stripe-mock":latest" -t ""stripe/stripe-mock":ec39425c3ff31dca6993447238e34f243250acc6" .
[+] Building 10.4s (13/13) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                         0.0s
 => => transferring dockerfile: 378B                                                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                                            0.0s
 => => transferring context: 97B                                                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                             1.0s
 => [internal] load metadata for docker.io/library/golang:alpine                                                                                                             1.1s
 => [builder 1/4] FROM docker.io/library/golang:alpine@sha256:fd9d9d7194ec40a9a6ae89fcaef3e47c47de7746dd5848ab5343695dbbd09f8c                                               0.0s
 => [internal] load build context                                                                                                                                            0.0s
 => => transferring context: 29.41kB                                                                                                                                         0.0s
 => [stage-1 1/3] FROM docker.io/library/alpine:latest@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1                                               0.0s
 => CACHED [builder 2/4] WORKDIR /app                                                                                                                                        0.0s
 => [builder 3/4] COPY . .                                                                                                                                                   0.4s
 => [builder 4/4] RUN go build -mod=vendor -o stripe-mock                                                                                                                    8.7s
 => CACHED [stage-1 2/3] RUN apk --no-cache add ca-certificates                                                                                                              0.0s
 => CACHED [stage-1 3/3] COPY --from=builder /app/stripe-mock /bin/stripe-mock                                                                                               0.0s
 => exporting to image                                                                                                                                                       0.0s
 => => exporting layers                                                                                                                                                      0.0s
 => => writing image sha256:863da4fb1c392371d60efc517daba71cfa300cb924128b88763042dc522b2776                                                                                 0.0s
 => => naming to docker.io/stripe/stripe-mock:latest                                                                                                                         0.0s
 => => naming to docker.io/stripe/stripe-mock:ec39425c3ff31dca6993447238e34f243250acc6                                                                                       0.0s
stripe-mock > hyperswitch-stripe-mock > docker run --rm stripe/stripe-mock:latest
stripe-mock master
Routing to 305 path(s) and 452 endpoint(s) with 452 validator(s)
Listening for HTTP at address: [::]:12111
Listening for HTTPS at address: [::]:12112
^C%
```