### PR TITLE
Separate dockerfile for goreleaser

### DIFF
--- a/goreleaser.dockerfile
+++ b/goreleaser.dockerfile
@@ -1,0 +1,8 @@
+# -*- mode: dockerfile -*-
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+COPY stripe-mock /bin/stripe-mock
+ENTRYPOINT ["/bin/stripe-mock", "-http-port", "12111", "-https-port", "12112"]
+EXPOSE 12111
+EXPOSE 12112

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -59,6 +59,7 @@ nfpms:
     - rpm
 
 dockers:
+  - dockerfile: 'goreleaser.dockerfile'
   - image_templates:
       - "stripe/stripe-mock:{{ .Tag }}-amd64"
       - "stripe/stripe-mock:latest-amd64"

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -59,7 +59,7 @@ nfpms:
     - rpm
 
 dockers:
-  - dockerfile: 'goreleaser.dockerfile'
+  - dockerfile: goreleaser.dockerfile
   - image_templates:
       - "stripe/stripe-mock:{{ .Tag }}-amd64"
       - "stripe/stripe-mock:latest-amd64"


### PR DESCRIPTION
Turns out #430 isn't compatible with goreleaser, which seems obvious in retrospect. I found [goreleaser docs](https://goreleaser.com/errors/docker-build) that suggest
> If you still want your users to be able to docker build without an extra step, you can have a Dockerfile just for GoReleaser, for example, a goreleaser.dockefile.

so, this PR is that.
