### PR TITLE
Fix dockerfile setting

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -59,7 +59,6 @@ nfpms:
     - rpm
 
 dockers:
-  - dockerfile: goreleaser.dockerfile
   - image_templates:
       - "stripe/stripe-mock:{{ .Tag }}-amd64"
       - "stripe/stripe-mock:latest-amd64"
@@ -68,6 +67,7 @@ dockers:
     goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
+    dockerfile: goreleaser.dockerfile
   - image_templates:
       - "stripe/stripe-mock:{{ .Tag }}-arm64"
       - "stripe/stripe-mock:latest-arm64"
@@ -76,6 +76,7 @@ dockers:
     goarch: arm64
     build_flag_templates:
       - "--platform=linux/arm64"
+    dockerfile: goreleaser.dockerfile
 
 docker_manifests:
   - name_template: "stripe/stripe-mock:{{ .Tag }}"


### PR DESCRIPTION
In https://github.com/stripe/stripe-mock/pull/432 the setting was added to the wrong place.

Confirmed that the correct dockerfile is picked up by running `goreleaser release --skip-publish --clean --verbose --skip-validate`