### PR TITLE
Generate synthetic fixtures for nullable types when expansions are requested

### DIFF
--- a/server/generator.go
+++ b/server/generator.go
@@ -315,7 +315,10 @@ func (g *DataGenerator) generateInternal(params *GenerateParams) (interface{}, e
 	}
 
 	// Generate a synthethic schema as a last ditch effort
-	if example == nil && schema.XResourceID == "" {
+	if (example == nil || example.value == nil) && schema.XResourceID == "" {
+		if schema.Nullable && params.Expansions != nil {
+			schema.Nullable = false
+		}
 		example = &valueWrapper{value: generateSyntheticFixture(schema, context)}
 
 		context = fmt.Sprintf("%sGenerated synthetic fixture: %+v\n", context, schema)

--- a/server/generator.go
+++ b/server/generator.go
@@ -739,7 +739,7 @@ func generateSyntheticFixture(schema *spec.Schema, context string, expansions *E
 
 	// Return the minimum viable object by returning nil/null for a nullable
 	// property, if that property does not need to be expanded.
-	if schema.Nullable && (expansions == nil) {
+	if schema.Nullable && expansions == nil {
 		return nil
 	}
 

--- a/server/generator_test.go
+++ b/server/generator_test.go
@@ -870,6 +870,29 @@ func TestGenerateSyntheticFixture(t *testing.T) {
 	)
 }
 
+func TestGenerateForNullableExpansion(t *testing.T) {
+	generator := DataGenerator{
+		definitions: realSpec.Components.Schemas,
+		fixtures:    &realFixtures,
+		verbose:     verbose,
+	}
+
+	var example interface{}
+	var err error
+	assert.NotPanics(t, func() {
+		example, err = generator.Generate(&GenerateParams{
+			Expansions: &ExpansionLevel{
+				expansions: map[string]*ExpansionLevel{"account_tax_ids": {
+					expansions: map[string]*ExpansionLevel{}},
+				},
+			},
+			Schema: &spec.Schema{Ref: "#/components/schemas/invoice"},
+		})
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, example)
+}
+
 func TestPropertyNames(t *testing.T) {
 	assert.Equal(t, "bar, foo", propertyNames(&spec.Schema{
 		Properties: map[string]*spec.Schema{

--- a/server/generator_test.go
+++ b/server/generator_test.go
@@ -812,23 +812,23 @@ func TestFindAnyOfBranch(t *testing.T) {
 
 func TestGenerateSyntheticFixture(t *testing.T) {
 	// Scalars (and an array, which is easy)
-	assert.Equal(t, []string{}, generateSyntheticFixture(&spec.Schema{Type: spec.TypeArray}, ""))
-	assert.Equal(t, true, generateSyntheticFixture(&spec.Schema{Type: spec.TypeBoolean}, ""))
-	assert.Equal(t, 0, generateSyntheticFixture(&spec.Schema{Type: spec.TypeInteger}, ""))
-	assert.Equal(t, 0.0, generateSyntheticFixture(&spec.Schema{Type: spec.TypeNumber}, ""))
-	assert.Equal(t, "", generateSyntheticFixture(&spec.Schema{Type: spec.TypeString}, ""))
+	assert.Equal(t, []string{}, generateSyntheticFixture(&spec.Schema{Type: spec.TypeArray}, "", nil))
+	assert.Equal(t, true, generateSyntheticFixture(&spec.Schema{Type: spec.TypeBoolean}, "", nil))
+	assert.Equal(t, 0, generateSyntheticFixture(&spec.Schema{Type: spec.TypeInteger}, "", nil))
+	assert.Equal(t, 0.0, generateSyntheticFixture(&spec.Schema{Type: spec.TypeNumber}, "", nil))
+	assert.Equal(t, "", generateSyntheticFixture(&spec.Schema{Type: spec.TypeString}, "", nil))
 
 	// Nullable property
 	assert.Equal(t, nil, generateSyntheticFixture(&spec.Schema{
 		Nullable: true,
 		Type:     spec.TypeString,
-	}, ""))
+	}, "", nil))
 
 	// Property with enum
 	assert.Equal(t, "list", generateSyntheticFixture(&spec.Schema{
 		Enum: []interface{}{"list"},
 		Type: spec.TypeString,
-	}, ""))
+	}, "", nil))
 
 	// Takes the first non-reference branch of an anyOf
 	assert.Equal(t, "", generateSyntheticFixture(&spec.Schema{
@@ -836,7 +836,7 @@ func TestGenerateSyntheticFixture(t *testing.T) {
 			{Ref: "#/components/schemas/radar_rule"},
 			{Type: spec.TypeString},
 		},
-	}, ""))
+	}, "", nil))
 
 	// Object
 	assert.Equal(t,
@@ -866,7 +866,30 @@ func TestGenerateSyntheticFixture(t *testing.T) {
 				"object",
 				"url",
 			},
-		}, ""),
+		}, "", nil),
+	)
+
+	// Nullable object property with expansion
+	assert.Equal(t,
+		map[string]interface{}{
+			"foo": "",
+		},
+		generateSyntheticFixture(&spec.Schema{
+			Type:     "object",
+			Nullable: true,
+			Properties: map[string]*spec.Schema{
+				"foo": {
+					Type: "string",
+				},
+			},
+			Required: []string{
+				"foo",
+			},
+		}, "", &ExpansionLevel{
+			expansions: map[string]*ExpansionLevel{"foo": {
+				expansions: map[string]*ExpansionLevel{}},
+			},
+		}),
 	)
 }
 


### PR DESCRIPTION
The issue in https://github.com/stripe/stripe-mock/issues/445 is caused by [a crash](https://github.com/stripe/stripe-mock/blob/1f05c0034db7407b9d77724f532f508ead46a1fb/server/generator.go#L339) when you try to expand a nullable attribute:

```
$ stripe-mock
stripe-mock 0.159.0
Routing to 306 path(s) and 453 endpoint(s) with 453 validator(s)
Listening for HTTP at address: [::]:12111
Listening for HTTPS at address: [::]:12112
Request: GET /v1/invoices/in_1NhTSDJ7Bu9fw2TI7tY1f5zD
Request data = map[expand:[account_tax_ids]]
2023/08/25 15:27:12 http: panic serving 127.0.0.1:53788: Responding to GET /v1/invoices/in_1NhTSDJ7Bu9fw2TI7tY1f5zD:
Dereferencing '#/components/schemas/invoice':
Using fixture 'invoice':
In property 'account_tax_ids' of object:
We were asked to expand a key, but our example has null for that key.
goroutine 49 [running]:
net/http.(*conn).serve.func1()
	/opt/hostedtoolcache/go/1.19.7/x64/src/net/http/server.go:1850 +0xb0
panic({0x100e9c660, 0x140018e3560})
	/opt/hostedtoolcache/go/1.19.7/x64/src/runtime/panic.go:890 +0x258
github.com/stripe/stripe-mock/server.(*DataGenerator).generateInternal(0x140010398f8, 0x14001acf320)
	/home/runner/work/stripe-mock/stripe-mock/server/generator.go:339 +0xe2c
github.com/stripe/stripe-mock/server.(*DataGenerator).generateInternal(0x140010398f8, 0x14001039670)
	/home/runner/work/stripe-mock/stripe-mock/server/generator.go:399 +0x10dc
github.com/stripe/stripe-mock/server.(*DataGenerator).Generate(0x140010398f8, 0x14001039950)
	/home/runner/work/stripe-mock/stripe-mock/server/generator.go:105 +0x114
github.com/stripe/stripe-mock/server.(*StubServer).HandleRequest(0x140008ea260, {0x100f044a8, 0x1400081ba40}, 0x14001ab0000)
	/home/runner/work/stripe-mock/stripe-mock/server/server.go:353 +0x968
net/http.HandlerFunc.ServeHTTP(0x14001ab9a38?, {0x100f044a8?, 0x1400081ba40?}, 0x100d6f7e8?)
	/opt/hostedtoolcache/go/1.19.7/x64/src/net/http/server.go:2109 +0x38
net/http.(*ServeMux).ServeHTTP(0x140003dc0a4?, {0x100f044a8, 0x1400081ba40}, 0x14001ab0000)
	/opt/hostedtoolcache/go/1.19.7/x64/src/net/http/server.go:2487 +0x140
github.com/stripe/stripe-mock/server.(*DoubleSlashFixHandler).ServeHTTP(0x140018a29c0, {0x100f044a8, 0x1400081ba40}, 0x14001ab0000)
	/home/runner/work/stripe-mock/stripe-mock/server/server.go:47 +0xb0
net/http.serverHandler.ServeHTTP({0x14001a9a1b0?}, {0x100f044a8, 0x1400081ba40}, 0x14001ab0000)
	/opt/hostedtoolcache/go/1.19.7/x64/src/net/http/server.go:2947 +0x2c4
net/http.(*conn).serve(0x14001aaa000, {0x100f049a0, 0x14001a9a0c0})
	/opt/hostedtoolcache/go/1.19.7/x64/src/net/http/server.go:1991 +0x560
created by net/http.(*Server).Serve
	/opt/hostedtoolcache/go/1.19.7/x64/src/net/http/server.go:3102 +0x444

```

This is because `generateSyntheticFixtures`  [defaults to returning `nil` if the property is nullable](https://github.com/stripe/stripe-mock/blob/1f05c0034db7407b9d77724f532f508ead46a1fb/server/generator.go#L740-L744). However, this poses an issue when we want to expand that nullable field.

This PR updates `generateSyntheticFixtures` to check expansions and generate non-`nil` fixtures for nullable properties if they're being expanded.