### PR TITLE
Revert "Generate synthetic fixtures for nullable types when expansions are requested (#446)"

### DIFF
--- a/server/generator.go
+++ b/server/generator.go
@@ -315,8 +315,8 @@ func (g *DataGenerator) generateInternal(params *GenerateParams) (interface{}, e
 	}
 
 	// Generate a synthethic schema as a last ditch effort
-	if (example == nil || example.value == nil) && schema.XResourceID == "" {
-		example = &valueWrapper{value: generateSyntheticFixture(schema, context, params.Expansions)}
+	if example == nil && schema.XResourceID == "" {
+		example = &valueWrapper{value: generateSyntheticFixture(schema, context)}
 
 		context = fmt.Sprintf("%sGenerated synthetic fixture: %+v\n", context, schema)
 
@@ -734,12 +734,12 @@ func distributeReplacedIDsInValue(pathParams *PathParamsMap, value interface{}) 
 // This function calls itself recursively by initially iterating through every
 // property in an object schema, then recursing and returning values for
 // embedded objects and scalars.
-func generateSyntheticFixture(schema *spec.Schema, context string, expansions *ExpansionLevel) interface{} {
+func generateSyntheticFixture(schema *spec.Schema, context string) interface{} {
 	context = fmt.Sprintf("%sGenerating synthetic fixture: %+v\n", context, schema)
 
 	// Return the minimum viable object by returning nil/null for a nullable
-	// property, if that property does not need to be expanded.
-	if schema.Nullable && expansions == nil {
+	// property.
+	if schema.Nullable {
 		return nil
 	}
 
@@ -755,8 +755,7 @@ func generateSyntheticFixture(schema *spec.Schema, context string, expansions *E
 			if subSchema.Ref != "" {
 				continue
 			}
-
-			return generateSyntheticFixture(subSchema, context, expansions)
+			return generateSyntheticFixture(subSchema, context)
 		}
 		panic(fmt.Sprintf("%sCouldn't find an anyOf branch to take", context))
 	}
@@ -783,12 +782,7 @@ func generateSyntheticFixture(schema *spec.Schema, context string, expansions *E
 				continue
 			}
 
-			var propertyExpansions *ExpansionLevel
-			if expansions != nil && expansions.expansions[property] != nil {
-				propertyExpansions = expansions.expansions[property]
-			}
-
-			fixture[property] = generateSyntheticFixture(subSchema, context, propertyExpansions)
+			fixture[property] = generateSyntheticFixture(subSchema, context)
 		}
 		return fixture
 

--- a/server/generator_test.go
+++ b/server/generator_test.go
@@ -812,23 +812,23 @@ func TestFindAnyOfBranch(t *testing.T) {
 
 func TestGenerateSyntheticFixture(t *testing.T) {
 	// Scalars (and an array, which is easy)
-	assert.Equal(t, []string{}, generateSyntheticFixture(&spec.Schema{Type: spec.TypeArray}, "", nil))
-	assert.Equal(t, true, generateSyntheticFixture(&spec.Schema{Type: spec.TypeBoolean}, "", nil))
-	assert.Equal(t, 0, generateSyntheticFixture(&spec.Schema{Type: spec.TypeInteger}, "", nil))
-	assert.Equal(t, 0.0, generateSyntheticFixture(&spec.Schema{Type: spec.TypeNumber}, "", nil))
-	assert.Equal(t, "", generateSyntheticFixture(&spec.Schema{Type: spec.TypeString}, "", nil))
+	assert.Equal(t, []string{}, generateSyntheticFixture(&spec.Schema{Type: spec.TypeArray}, ""))
+	assert.Equal(t, true, generateSyntheticFixture(&spec.Schema{Type: spec.TypeBoolean}, ""))
+	assert.Equal(t, 0, generateSyntheticFixture(&spec.Schema{Type: spec.TypeInteger}, ""))
+	assert.Equal(t, 0.0, generateSyntheticFixture(&spec.Schema{Type: spec.TypeNumber}, ""))
+	assert.Equal(t, "", generateSyntheticFixture(&spec.Schema{Type: spec.TypeString}, ""))
 
 	// Nullable property
 	assert.Equal(t, nil, generateSyntheticFixture(&spec.Schema{
 		Nullable: true,
 		Type:     spec.TypeString,
-	}, "", nil))
+	}, ""))
 
 	// Property with enum
 	assert.Equal(t, "list", generateSyntheticFixture(&spec.Schema{
 		Enum: []interface{}{"list"},
 		Type: spec.TypeString,
-	}, "", nil))
+	}, ""))
 
 	// Takes the first non-reference branch of an anyOf
 	assert.Equal(t, "", generateSyntheticFixture(&spec.Schema{
@@ -836,7 +836,7 @@ func TestGenerateSyntheticFixture(t *testing.T) {
 			{Ref: "#/components/schemas/radar_rule"},
 			{Type: spec.TypeString},
 		},
-	}, "", nil))
+	}, ""))
 
 	// Object
 	assert.Equal(t,
@@ -866,54 +866,8 @@ func TestGenerateSyntheticFixture(t *testing.T) {
 				"object",
 				"url",
 			},
-		}, "", nil),
+		}, ""),
 	)
-
-	// Nullable object property with expansion
-	assert.Equal(t,
-		map[string]interface{}{
-			"foo": "",
-		},
-		generateSyntheticFixture(&spec.Schema{
-			Type:     "object",
-			Nullable: true,
-			Properties: map[string]*spec.Schema{
-				"foo": {
-					Type: "string",
-				},
-			},
-			Required: []string{
-				"foo",
-			},
-		}, "", &ExpansionLevel{
-			expansions: map[string]*ExpansionLevel{"foo": {
-				expansions: map[string]*ExpansionLevel{}},
-			},
-		}),
-	)
-}
-
-func TestGenerateForNullableExpansion(t *testing.T) {
-	generator := DataGenerator{
-		definitions: realSpec.Components.Schemas,
-		fixtures:    &realFixtures,
-		verbose:     verbose,
-	}
-
-	var example interface{}
-	var err error
-	assert.NotPanics(t, func() {
-		example, err = generator.Generate(&GenerateParams{
-			Expansions: &ExpansionLevel{
-				expansions: map[string]*ExpansionLevel{"account_tax_ids": {
-					expansions: map[string]*ExpansionLevel{}},
-				},
-			},
-			Schema: &spec.Schema{Ref: "#/components/schemas/invoice"},
-		})
-	})
-	assert.NoError(t, err)
-	assert.NotNil(t, example)
 }
 
 func TestPropertyNames(t *testing.T) {


### PR DESCRIPTION
This reverts commit 1d80bcc48dea3aab3e43c58bad2dcb455b880433.

This commit breaks some stripe-mock usages, as mentioned in https://github.com/stripe/stripe-mock/issues/447