### PR TITLE
Replace broken Travis CI status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# stripe-mock [![Build Status](https://travis-ci.org/stripe/stripe-mock.svg?branch=master)](https://travis-ci.org/stripe/stripe-mock)
+# stripe-mock [![Build Status](https://github.com/stripe/stripe-mock/actions/workflows/ci.yml/badge.svg)](https://github.com/stripe/stripe-mock/actions/workflows/ci.yml)
 
 stripe-mock is a mock HTTP server based on the real Stripe API. It accepts the
 same requests and parameters that the Stripe API accepts, and rejects requests


### PR DESCRIPTION
Travis hasn't been in use in this repo since 2021 (e7223678959a07d025da2a743def234d2263e973).