### PR TITLE
Update Go version to 1.22.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.22.1
       - name: test
         run: |
           go install golang.org/x/lint/golint@latest &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.22.1
       # Fetch app token
       - uses: tibdex/github-app-token@v1.5.2
         id: gh-api-token

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stripe/stripe-mock
 
-go 1.19
+go 1.22.1
 
 require (
 	github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2 // indirect


### PR DESCRIPTION
CI has been failing on the automated PR with the below error:

<img width="1153" alt="Screenshot 2024-09-04 at 10 34 37 PM" src="https://github.com/user-attachments/assets/63f26aab-6426-4aa0-8db0-8bac929f5914">

Based on https://github.com/dominikh/go-tools/issues/1592, the static analysis tool we are using needs a min of 1.22.1 version of go