### PR TITLE
Make branch name configurable in update-openapi-spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GIT_COMMITSHA = $(shell git rev-parse HEAD)
 IMAGE_NAME = "stripe/stripe-mock"
+OPENAPI_BRANCH ?= master
 
 all: test vet lint check-gofmt build
 
@@ -30,6 +31,6 @@ docker-run:
 update-openapi-spec:
 	rm -f ./embedded/openapi/spec3.json
 	rm -f ./embedded/openapi/fixtures3.json
-	wget https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json -P ./embedded/openapi
-	wget https://raw.githubusercontent.com/stripe/openapi/master/openapi/fixtures3.json -P ./embedded/openapi
+	wget https://raw.githubusercontent.com/stripe/openapi/$(OPENAPI_BRANCH)/openapi/spec3.json -P ./embedded/openapi
+	wget https://raw.githubusercontent.com/stripe/openapi/$(OPENAPI_BRANCH)/openapi/fixtures3.json -P ./embedded/openapi
 .PHONY: update-openapi-spec

--- a/embedded/openapi/fixtures3.json
+++ b/embedded/openapi/fixtures3.json
@@ -2468,7 +2468,8 @@
       "object": "issuing.settlement",
       "settlement_service": "international",
       "transaction_count": 2,
-      "transaction_volume": 3656
+      "transaction_volume": 3656,
+      "status": "complete"
     },
     "issuing.token": {
       "card": "ic_1Pgag5B7WZ01zgkWephORn8N",

--- a/embedded/openapi/fixtures3.json
+++ b/embedded/openapi/fixtures3.json
@@ -2468,8 +2468,7 @@
       "object": "issuing.settlement",
       "settlement_service": "international",
       "transaction_count": 2,
-      "transaction_volume": 3656,
-      "status": "complete"
+      "transaction_volume": 3656
     },
     "issuing.token": {
       "card": "ic_1Pgag5B7WZ01zgkWephORn8N",
@@ -3538,7 +3537,24 @@
     "scheduled_query_run": {
       "created": 1234567890,
       "data_load_time": 1234567890,
-      "file": null,
+      "file": {
+        "created": 1721948551,
+        "expires_at": null,
+        "filename": "path",
+        "id": "file_1Pgag7B7WZ01zgkWJbdoNCXR",
+        "links": {
+          "data": [],
+          "has_more": false,
+          "object": "list",
+          "url": "/v1/file_links?file=file_1Pgag7B7WZ01zgkWJbdoNCXR"
+        },
+        "object": "file",
+        "purpose": "sigma_scheduled_query",
+        "size": 500,
+        "title": null,
+        "type": "csv",
+        "url": "https://sangeekp-15t6ai--upload-mydev.dev.stripe.me/v1/files/file_1Pgag7B7WZ01zgkWJbdoNCXR/contents"
+      },
       "id": "sqr_1Pgc7AB7WZ01zgkWvpIic1Di",
       "livemode": false,
       "object": "scheduled_query_run",


### PR DESCRIPTION
### Why?
When working on https://github.com/stripe/openapi/pull/157, it was convenient to be able to specify the branch name to pull from in the update step.  This let me test the changes end to end before merging the PRs.  This PR makes this configurability official.

### What?
- adds OPENAPI_BRANCH Makefile variable that update-openapi-spec can use to select a branch to pull from.  defaults to master.