### PR TITLE
Add explicit permissions to GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,17 @@
 
 on: [push, pull_request]
 name: CI
+
+permissions: {}
+
 jobs:
   test:
     name: Test
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,13 @@ on:
     tags:
       - "v*"
 
+permissions: {}
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Code checkout
         uses: actions/checkout@v2

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,9 +8,14 @@ on:
       sha:
         description: "Commit SHA to tag. Defaults to latest."
         required: false
+
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Code checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
### Why?
Fix code scanning alerts about unlimited permissions in GitHub workflows. By default, workflows have read/write access to all scopes, which is a security concern. This change applies the principle of least privilege.

### What?
- Added `permissions: {}` at workflow level to restrict default permissions
- Added `contents: read` permission to each job that needs repository access
- Note: release.yml and tag.yml use GitHub App tokens for write operations, not GITHUB_TOKEN

### See Also
- [GitHub docs on workflow permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)