### PR TITLE
Add x-stableId to supported schema fields

### DIFF
--- a/spec/spec.go
+++ b/spec/spec.go
@@ -94,6 +94,10 @@ var supportedSchemaFields = []string{
 	// Schema yet. If we do start validating responses that come out of
 	// stripe-mock, we may need to observe this as well.
 	"x-stripeBypassValidation",
+
+	// A stable identifier for schema elements, used for tracking across spec
+	// versions. Not needed by stripe-mock.
+	"x-stableId",
 }
 
 // Schema is a struct representing a JSON schema.


### PR DESCRIPTION
### Why?

The OpenAPI spec v2250+ includes a new `x-stableId` extension field on schema objects. stripe-mock's custom `UnmarshalJSON` on `Schema` rejects any field not in an explicit allowlist (`supportedSchemaFields`), causing a crash on startup:

```
error decoding spec: unsupported field in JSON schema: 'x-stableId'
```

### What?

Added `x-stableId` to the `supportedSchemaFields` allowlist in `spec/spec.go`. This is a metadata field for tracking stable schema identifiers across spec versions — stripe-mock doesn't need to interpret it, just tolerate its presence during parsing.

## Changelog

- Fixed crash on startup when loading OpenAPI spec v2250+ by adding `x-stableId` to the supported schema fields allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)