### PR TITLE
Fix vulnerable Go version in release workflow (fixes #1637)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -23,11 +23,11 @@ jobs:
         run: |
           echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.22.1
+          go-version: stable
       # Fetch app token
       - uses: tibdex/github-app-token@v1.5.2
         id: gh-api-token
@@ -35,10 +35,10 @@ jobs:
           app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
           private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: v1.7
-          args: release -f goreleaser.yml --rm-dist
+          version: ~v2.16.0
+          args: release -f goreleaser.yml --clean
         env:
           GITHUB_TOKEN: ${{ steps.gh-api-token.outputs.token }}
       - uses: stripe/openapi/actions/notify-release@master

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -20,7 +20,7 @@ builds:
       - arm64
 
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 
 archives:
   - format_overrides:
@@ -28,7 +28,7 @@ archives:
         format: zip
 
 brews:
-  - tap:
+  - repository:
       owner: stripe
       name: homebrew-stripe-mock
     homepage: "https://github.com/stripe/stripe-mock"

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -25,7 +25,7 @@ snapshot:
 archives:
   - format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 brews:
   - repository:


### PR DESCRIPTION
### Why?

The release workflow pinned `go-version: 1.22.1` via the outdated `actions/setup-go@v2`. As reported in #1637, released binaries were being compiled with Go 1.25.0, which carries [CVE-2025-68121](https://www.cvedetails.com/cve/CVE-2025-68121/) and several other CVEs. The `ci.yml` workflow already used `go-version: stable` correctly — this brings the release workflow in line.

### What?

- **`release.yml`**: Switch `go-version` to `stable` so binaries always build against the current non-vulnerable Go toolchain. Also update stale actions: `checkout@v2→v4`, `setup-go@v2→v6`, `setup-buildx-action@v2→v3`, `goreleaser-action@v2→v6` (goreleaser v1.7→v2.16.0), and `--rm-dist→--clean` (goreleaser v2 rename).
- **`goreleaser.yml`**: Two required goreleaser v2 config migrations: `snapshot.name_template→version_template`, `brews[].tap→brews[].repository`.

## Changelog

- Fixed release workflow to build binaries against the current stable Go version instead of a pinned vulnerable version (resolves #1637).