### PR TITLE
add missing `x-stripeEnum` property

### DIFF
--- a/spec/spec.go
+++ b/spec/spec.go
@@ -85,6 +85,7 @@ var supportedSchemaFields = []string{
 	"x-stripeOperations",
 	"x-stripeParam",
 	"x-stripeEvent",
+	"x-stripeEnum",
 	"x-stripeMostCommon",
 	// This isn't used in our SDK, but is additional metadata unnecessary for
 	// stripe-mock.


### PR DESCRIPTION
Stripe mock is strict about which keys are allowed to exist in the spec. Since we added `x-stripeEnum`, we have to add it here as well. Without it, it crashes.